### PR TITLE
feat: SYLT lyrics + Mixed In Key reader + meedya-core facade extensions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,13 +38,14 @@ Rust workspace, 9 crates, 211 tests passing. Two co-existing tag-I/O foundations
 
 ## Key design principles
 
-1. **Results only, not side effects**: Crates return data; consumers handle I/O (file writes, UI updates, DB persistence).
-2. **Config-driven where possible**: Tag definitions, codec registries etc. loaded from TOML — zero Rust changes to add entries.
-3. **No app-specific logic**: No Tauri, no SwiftUI, no CLI framework dependencies in core crates.
-4. **FFI-friendly types**: Public types in crates targeted at Swift consumption should be C-FFI compatible.
-5. **Feature-gated heavy deps**: Large dependencies (`symphonia`, `rusty-chromaprint`, OS keyring) behind optional features.
-6. **Two tag-I/O foundations coexist intentionally** — `mp4ameta` for the sandbox-safe Apple Music flow, `lofty` for multi-format DJ-metadata and pass-through. Do not try to unify them.
-7. **Fixture-based testing for proprietary format parsers** — don't reverse-engineer Serato/Rekordbox/Traktor formats from memory. Require real tagged sample files.
+1. **Standards-first**: Use standard metadata tags (ID3v2 / Vorbis / MP4 ilst spec fields) wherever they exist. Fall back to `MeedyaMeta:*` freeform atoms **only** when no standard equivalent exists (e.g., DJ energy ratings, internal audit trails, MeedyaSuite-only soft-playback bounds). Standards-first applies to every crate — not just MIK or DJ-metadata.
+2. **Results only, not side effects**: Crates return data; consumers handle I/O (file writes, UI updates, DB persistence).
+3. **Config-driven where possible**: Tag definitions, codec registries etc. loaded from TOML — zero Rust changes to add entries.
+4. **No app-specific logic**: No Tauri, no SwiftUI, no CLI framework dependencies in core crates.
+5. **FFI-friendly types**: Public types in crates targeted at Swift consumption should be C-FFI compatible.
+6. **Feature-gated heavy deps**: Large dependencies (`symphonia`, `rusty-chromaprint`, OS keyring) behind optional features.
+7. **Two tag-I/O foundations coexist intentionally** — `mp4ameta` for the sandbox-safe Apple Music flow, `lofty` for multi-format DJ-metadata and pass-through. Do not try to unify them.
+8. **Fixture-based testing for proprietary format parsers** — don't reverse-engineer Serato/Rekordbox/Traktor formats from memory. Require real tagged sample files.
 
 ## Standing tasks
 

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -1,7 +1,7 @@
 # MeedyaSuite-core — Project Context
 
 > Snapshot maintained for Claude Code sessions. Reflects the actual state of `main`, not aspirational state.
-> Last updated: 2026-05-18 (post-PR #19 merge — consolidated 9-crate workspace).
+> Last updated: 2026-05-18 (post issues #26 SYLT + #27 facade re-exports + #31 Mixed In Key reader, on feature branch `claude/feature-batch-2026-05-18`).
 
 ## What this repo is
 
@@ -21,15 +21,15 @@ Apps consume this via direct Cargo git dependency (Rust apps) or C FFI / WASM bi
 |---|---|---|---|
 | [meedya-codecs](../crates/meedya-codecs/) | Audio/video/subtitle codecs, container formats, HDR, spatial audio, classification, FFprobe + MediaInfo integration | **Implemented** | 47 |
 | [meedya-metadata](../crates/meedya-metadata/) | Two coexisting tag I/O surfaces: `lofty`-backed (multi-format) and `mp4ameta`-backed (sandbox-safe). Tag registry, JSON path extraction, codec ID tags, playback bounds. | **Implemented** | 59 |
-| [meedya-tags-extended](../crates/meedya-tags-extended/) | Multi-format DJ metadata foundation (lofty). `ExtendedTags`/`MusicalKey`/`CuePoint`/`LoopPoint`/`BeatGrid`. Standard BPM+key+comment covers Mixed In Key. Proprietary readers pending. | **Implemented (foundation)** | 29 |
+| [meedya-tags-extended](../crates/meedya-tags-extended/) | Multi-format DJ metadata (lofty). `ExtendedTags`/`MusicalKey`/`CuePoint`/`LoopPoint`/`BeatGrid`. Standard BPM+key+comment + Mixed In Key reader (`mik`). Other proprietary readers pending. | **Implemented (foundation + MIK)** | 61 |
 | [meedya-library-import](../crates/meedya-library-import/) | External library ingestion: iTunes XML, CUE sheets. Emits normalized `LibraryEntry` records. | **Implemented** | 30 |
-| [meedya-lyrics](../crates/meedya-lyrics/) | LRCLIB client, LRC parser/writer, sidecar I/O, tag-embed via `meedya-metadata::CommonTag::Lyrics`. | **Implemented** | 10 |
+| [meedya-lyrics](../crates/meedya-lyrics/) | LRCLIB client, LRC parser/writer, sidecar I/O, plain-text and SYLT tag-embed. | **Implemented** | 15 |
 | [meedya-providers](../crates/meedya-providers/) | Provider framework: traits, capabilities, rate limiting, credentials, cover art, fuzzy match scoring. | **Implemented** | 27 |
 | [meedya-fingerprint](../crates/meedya-fingerprint/) | AcoustID client + ReplayGain EBU R128 analyser. Pure-Rust Chromaprint (no fpcalc). | **Implemented** | 6 |
 | [meedya-db](../crates/meedya-db/) | MeedyaDB API client + `Track`/`Album`/`Artist` models + `DbExporter` trait. | **Implemented** | 3 |
 | [meedya-core](../crates/meedya-core/) | Facade re-exporting all implemented crates behind feature flags. | **Implemented** | — |
 
-**Total: 211 tests on `main`.** Workspace builds clean.
+**Total: 248 tests on feature branch (211 → 248 this batch).** Workspace builds clean.
 
 > **Public API specification for partner apps**: see [`docs/API.md`](../docs/API.md). Keep that file in sync with public API changes — see the standing task in [CLAUDE.md](CLAUDE.md#standing-tasks).
 
@@ -48,11 +48,12 @@ Two surfaces coexist by design:
 
 **Adding a new tag**: edit `tags.toml`, zero Rust changes (PROMPTS.md has the template).
 
-### meedya-tags-extended (foundation only)
+### meedya-tags-extended
 
 - [src/io.rs](../crates/meedya-tags-extended/src/io.rs) — `TagFile`: lofty-based open/edit/save with foreign-frame pass-through.
 - [src/model.rs](../crates/meedya-tags-extended/src/model.rs) — `ExtendedTags`, `Source` enum, `CuePoint`, `LoopPoint`, `BeatGrid`, `Rgb`, `MusicalKey` (Camelot/Open Key/traditional round-tripping).
-- [src/standard.rs](../crates/meedya-tags-extended/src/standard.rs) — BPM/key/comment read+write. Covers Mixed In Key fully.
+- [src/standard.rs](../crates/meedya-tags-extended/src/standard.rs) — BPM/key/comment read+write across all lofty-supported formats.
+- [src/mik.rs](../crates/meedya-tags-extended/src/mik.rs) — Mixed In Key reader. `read_mik(tag) -> MikAnalysis` scans every documented MIK write location (standard fields, artist/title prefixes+suffixes, comment, grouping, label) and recovers key/energy/tempo. `normalise_to_standards(tag, &analysis)` writes the canonical values to standard tag fields (only Energy falls back to `MeedyaMeta:Energy` because no standard exists). Source fields are read-only — user data preserved.
 
 **Pending** (one session each, fixture-driven): Serato (Markers2/Autotags/BeatGrid), Rekordbox (ID3 PRIV + XML sidecar), Traktor (cue frames + collection.nml), Virtual DJ (.vdj sidecar + embedded markers).
 
@@ -68,7 +69,7 @@ Two surfaces coexist by design:
 - [src/provider/](../crates/meedya-lyrics/src/provider/) — `LyricsProvider` trait + `LrclibProvider`.
 - [src/lrc.rs](../crates/meedya-lyrics/src/lrc.rs) — LRC parser/writer (`[mm:ss.xx]`).
 - [src/sidecar.rs](../crates/meedya-lyrics/src/sidecar.rs) — `.lrc` sidecar writes.
-- [src/embed.rs](../crates/meedya-lyrics/src/embed.rs) — Tag-embed via `meedya-metadata::CommonTag::Lyrics` (plain text USLT/©lyr/LYRICS). **SYLT synchronised ID3v2 not yet supported.**
+- [src/embed.rs](../crates/meedya-lyrics/src/embed.rs) — Two embed paths: `embed()` writes plain text via `meedya-metadata::CommonTag::Lyrics` (USLT/©lyr/LYRICS); `embed_synced()` writes ID3v2 SYLT frames (errors on non-ID3v2 containers). UTF-16 BOM, MS timestamp format, lyrics content type.
 
 ### meedya-providers
 
@@ -85,10 +86,11 @@ Provider framework. Re-exports: `MetadataProvider`, `ProviderCapabilities`, `Pro
 
 ### meedya-core
 
-Facade with feature flags (`metadata` / `codecs` / `fingerprint` / `lyrics` / `providers` / `db` / `keyring` / `full`). Re-exports each crate as a top-level module. `meedya_core::prelude` re-exports common types. **Does not yet re-export `meedya-tags-extended` or `meedya-library-import`** — flagged follow-up.
+Facade with feature flags (`metadata` / `codecs` / `fingerprint` / `lyrics` / `providers` / `tags-extended` / `library-import` / `db` / `keyring` / `full`). All implemented crates re-exported as top-level modules. `meedya_core::prelude` re-exports common types: `CommonTag`, `MetadataError`, `TagRegistry`, `AudioCodec`, `ChannelConfig`, `CodecRegistry`, `ContainerFormat`, `SpatialType`, `MetadataProvider`, `ProviderCapabilities`, `CredentialStore`, `ProviderRateLimiter`, `ProviderResult`, `SearchQuery`, `Lyrics`, `LyricsProvider`, `SyncedLine`, `TrackQuery`, `TagFile`, `ExtendedTags`, `MusicalKey`, `KeyMode`, `Note`, `CuePoint`, `LoopPoint`, `BeatGrid`, `Source`, `LibraryEntry`, `EntryLocator`, `ImportReport`, `SourceInfo`.
 
 ## Key design decisions
 
+0. **Standards-first** (project-wide policy). Use standard metadata tags (ID3v2 / Vorbis / MP4 ilst spec fields) wherever they exist. Fall back to `MeedyaMeta:*` freeform atoms only when no standard equivalent exists — e.g., DJ energy ratings, playback bounds, audit trails. See [CLAUDE.md → Key design principles](CLAUDE.md#key-design-principles).
 1. **Two tag-I/O foundations coexist.** `mp4ameta` for sandbox-safe Apple Music flow; `lofty` for multi-format DJ-metadata and general pass-through. Not unified — they serve different code paths.
 
 2. **Pass-through preservation.** `meedya-tags-extended::TagFile` round-trips unknown frames automatically (lofty design). MeedyaConverter re-encodes don't strip Serato/Rekordbox/Traktor blobs even when we don't model them.
@@ -107,7 +109,7 @@ Facade with feature flags (`metadata` / `codecs` / `fingerprint` / `lyrics` / `p
 
 ```bash
 cargo build --workspace          # all 9 crates
-cargo test  --workspace          # 211 tests
+cargo test  --workspace          # 248 tests
 cargo test  -p meedya-metadata   # single crate
 cargo doc   --workspace --no-deps --open  # exhaustive auto-generated reference
 ```

--- a/.claude/HISTORY.md
+++ b/.claude/HISTORY.md
@@ -125,14 +125,55 @@ Refreshed all repo documentation to reflect the 9-crate state:
 ### Standing task established
 `docs/API.md` is now the contractual integration reference for partner apps. The CLAUDE.md standing task requires it be updated in the SAME commit as any public API change (no follow-up PRs). The procedure is captured in PROMPTS.md.
 
-### Open follow-ups (pending GitHub issue creation)
-- Serato reader (Markers2/Autotags/BeatGrid)
-- Rekordbox reader (ID3 PRIV + XML sidecar)
-- Traktor reader (cue frames + collection.nml)
-- Virtual DJ reader (.vdj sidecar + embedded markers)
-- Bindings/swift scaffold
-- Bindings/wasm scaffold
-- `meedya-core`: re-export `meedya-tags-extended` and `meedya-library-import`
-- `meedya-lyrics`: SYLT (synchronised ID3v2 lyrics) support
-- Chapter authoring (consume `CueSheet` indexes, write MP4 `chap` + `chpl`)
-- CI: stale-API.md check via `cargo public-api` diff
+### Open follow-ups (now tracked as GitHub issues)
+Issues #21-#30 created later in this session covering: Serato (#21), Rekordbox (#22), Traktor (#23), Virtual DJ (#24), chapter authoring crate (#25), meedya-lyrics SYLT (#26), meedya-core re-exports (#27), bindings/swift scaffold (#28), bindings/wasm scaffold (#29), CI stale-API.md check (#30).
+
+---
+
+## 2026-05-18 (later) — Feature batch on `claude/feature-batch-2026-05-18`
+
+Worked through a subset of issues #21-#30 plus new Mixed In Key issue (#31). Honest scoping: implemented the items that are tractable without proprietary-format fixture files; deferred issues #21-#24 (Serato/Rekordbox/Traktor/VirtualDJ readers) and #25/#28/#29/#30 (chapters/bindings/CI) per the standing "fixture-based testing" and "needs infrastructure decisions" guardrails.
+
+### Standards-first policy adopted
+User direction during the session: standards-first across the entire project. Added to [`.claude/CLAUDE.md`](CLAUDE.md#key-design-principles) as design principle #1. Standard tag fields are preferred wherever they exist; `MeedyaMeta:*` freeform atoms are reserved for fields with no standard (energy ratings, soft playback bounds, audit trails).
+
+### Issue #27 — meedya-core re-exports (commit `db98b89`)
+Added `tags-extended` and `library-import` feature flags to `meedya-core`. Both in `default` and `full`. Prelude extended with `TagFile`, `ExtendedTags`, `MusicalKey`, `KeyMode`, `Note`, `CuePoint`, `LoopPoint`, `BeatGrid`, `Source`, `LibraryEntry`, `EntryLocator`, `ImportReport`, `SourceInfo`. Internal workspace.dependencies registered both crates.
+
+### Issue #26 — meedya-lyrics SYLT (commit `77762e3`)
+Added `embed_synced(media, lyrics, lang) -> Result<()>` for ID3v2 SYLT writes. Errors with `Error::UnsupportedForSync` on non-ID3v2 containers. Uses UTF-16 with BOM, millisecond timestamps. Lofty 0.22 doesn't expose SYLT as a first-class `Frame` variant, so the implementation serializes a `SynchronizedTextFrame` and wraps the bytes in a `BinaryFrame` with frame ID `SYLT` — the documented escape hatch. 5 new tests, 10 → 15 in meedya-lyrics.
+
+### Issue #31 (new) — Mixed In Key reader (commit `b501104`)
+Created during this session. Implementation in new `meedya-tags-extended::mik` module:
+- `read_mik(tag) -> MikAnalysis` scans every documented MIK write location: standard `InitialKey`+BPM, artist prefix, title prefix+suffix, comment whole+prefix+suffix, grouping energy prefix, label energy whole.
+- Token classification handles all 8 documented "what to write" MIK combinations: key only, energy with word, key+energy with word, energy alone, key+energy, key+tempo, key+tempo+energy, tempo+key+energy.
+- Greedy prefix/suffix matching: `"10A - 126 - 7 - www.beatport.com"` recovers all three datapoints AND leaves the URL untouched.
+- Camelot zero-padding (`05A`), all 4 notations (Camelot/OpenKey/sharps/flats traditional), handled by existing `MusicalKey::parse`.
+- `normalise_to_standards(tag, &analysis)` writes to standard `InitialKey`/`IntegerBpm`/`Bpm`; only Energy falls back to `MeedyaMeta:Energy` (no standard exists). `MeedyaMeta:MikSourceLocations` carries an audit trail.
+- Source fields are read-only — original artist/title/comment strings preserved verbatim.
+- 32 new tests, 29 → 61 in meedya-tags-extended.
+
+### Documentation refresh
+- [`.claude/CLAUDE.md`](CLAUDE.md): added **standards-first** as design principle #1 (project-wide policy).
+- [`docs/API.md`](../docs/API.md): updated meedya-core feature flags + prelude, meedya-lyrics SYLT API, meedya-tags-extended `mik` module section, two new common-workflow examples, bumped test count 211 → 248.
+- [`.claude/CONTEXT.md`](CONTEXT.md): refreshed crate table for new test counts, added MIK module to tags-extended description, added standards-first to design decisions.
+
+### Deferred (with rationale)
+Issues #21-#24 (Serato/Rekordbox/Traktor/VirtualDJ readers) — explicitly say in their own bodies "DO NOT reverse-engineer from memory" and require real DJ-tagged fixture files. Implementing from memory in this session would produce subtly broken parsers that corrupt user DJ work — exactly the failure mode the guardrails were written to prevent.
+
+Issue #25 (chapters crate) — "Large" complexity, requires a prototype phase to choose between mp4ameta / mp4parse-rust / bento4 / hand-written atom emitters.
+
+Issue #28 (Swift bindings) — "Large" complexity, multi-tool multi-target, infrastructure decisions (cbindgen vs uniffi) best made together with the MeedyaConverter team.
+
+Issue #29 (WASM bindings) — "Medium" complexity, also needs scope decisions about what surface to expose given browser CORS / no-filesystem constraints.
+
+Issue #30 (CI stale-API check workflow) — needs PR-cycle iteration to validate the workflow YAML; committing untested CI code from a single session is risky.
+
+### Branching strategy
+All work this session is on `claude/feature-batch-2026-05-18` per user instruction. No PR opened — the user wants a single PR at the end consolidating all batch changes for a release. Workspace builds clean; 248 tests passing.
+
+### Commits on `claude/feature-batch-2026-05-18`
+- `db98b89` feat(meedya-core): re-export meedya-tags-extended and meedya-library-import
+- `77762e3` feat(meedya-lyrics): implement synchronised ID3v2 SYLT writer
+- `b501104` feat(meedya-tags-extended): Mixed In Key reader with standards-first normalisation
+- (this commit) docs: refresh API.md / CONTEXT.md / CLAUDE.md / HISTORY.md for the batch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,9 +908,11 @@ dependencies = [
  "meedya-codecs",
  "meedya-db",
  "meedya-fingerprint",
+ "meedya-library-import",
  "meedya-lyrics",
  "meedya-metadata",
  "meedya-providers",
+ "meedya-tags-extended",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ name = "meedya-lyrics"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "lofty 0.22.4",
  "meedya-metadata",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ meedya-codecs = { path = "crates/meedya-codecs" }
 meedya-core = { path = "crates/meedya-core" }
 meedya-db = { path = "crates/meedya-db" }
 meedya-fingerprint = { path = "crates/meedya-fingerprint" }
+meedya-library-import = { path = "crates/meedya-library-import" }
 meedya-lyrics = { path = "crates/meedya-lyrics" }
 meedya-metadata = { path = "crates/meedya-metadata" }
 meedya-providers = { path = "crates/meedya-providers" }
+meedya-tags-extended = { path = "crates/meedya-tags-extended" }

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Written in Rust. Distributable to all Meedya apps via:
 |---|---|---|---|
 | [`meedya-codecs`](crates/meedya-codecs) | Audio/video/subtitle codecs, container formats, HDR, spatial audio, media classification, FFprobe + MediaInfo integration | Implemented | 47 |
 | [`meedya-metadata`](crates/meedya-metadata) | Two coexisting tag-I/O surfaces: lofty-backed multi-format (`CommonTag`, `tag_io`, `tag_registry`) and `mp4ameta`-backed sandbox-safe registry for the Apple Music tagging flow. Includes `playback_bounds` (soft start/stop atoms) and codec ID tags. | Implemented | 59 |
-| [`meedya-tags-extended`](crates/meedya-tags-extended) | Multi-format tag I/O foundation with DJ metadata support. `ExtendedTags` model, `MusicalKey` (Camelot/Open Key/traditional), `CuePoint`/`LoopPoint`/`BeatGrid`, standard BPM+key+comment read/write covering Mixed In Key. Proprietary readers (Serato/Rekordbox/Traktor/VDJ) pending fixture-based sessions. | Implemented | 29 |
+| [`meedya-tags-extended`](crates/meedya-tags-extended) | Multi-format tag I/O foundation with DJ metadata support. `ExtendedTags` model, `MusicalKey` (Camelot/Open Key/traditional), `CuePoint`/`LoopPoint`/`BeatGrid`, standard BPM+key+comment read/write, **Mixed In Key reader** (`mik` module). Other proprietary readers (Serato/Rekordbox/Traktor/VDJ) pending fixture-based sessions. | Implemented | 61 |
 | [`meedya-library-import`](crates/meedya-library-import) | Ingest playback bounds + metadata from external library DBs. `itunes_xml` parses Music.app exports; `cuesheet` is a full CUE parser at CD-frame precision. | Implemented | 30 |
-| [`meedya-lyrics`](crates/meedya-lyrics) | LRCLIB client, LRC parser/writer, `.lrc` sidecar writes, tag-embed via `meedya-metadata` `CommonTag::Lyrics`. | Implemented | 10 |
+| [`meedya-lyrics`](crates/meedya-lyrics) | LRCLIB client, LRC parser/writer, `.lrc` sidecar writes, plain-text + synchronised ID3v2 SYLT tag-embed. | Implemented | 15 |
 | [`meedya-providers`](crates/meedya-providers) | Metadata provider framework: traits, capabilities, registry, rate limiting, cover art helpers, match scoring. | Implemented | 27 |
 | [`meedya-fingerprint`](crates/meedya-fingerprint) | AcoustID fingerprinting + ReplayGain/EBU R128 loudness analysis. | Implemented | 6 |
 | [`meedya-db`](crates/meedya-db) | MeedyaDB API client, shared media models (Track/Album/Artist), database export trait. | Implemented | 3 |
 | [`meedya-core`](crates/meedya-core) | Unified facade crate re-exporting the implemented crates behind feature flags. | Implemented | — |
 
-**Total: 211 tests passing**, workspace builds clean.
+**Total: 248 tests passing**, workspace builds clean.
 
 ## Quick Start
 
@@ -30,7 +30,7 @@ Written in Rust. Distributable to all Meedya apps via:
 # Build all crates
 cargo build --workspace
 
-# Run the full test suite (211 tests)
+# Run the full test suite (248 tests)
 cargo test --workspace
 
 # Build a single crate
@@ -85,7 +85,8 @@ Cross-format `CommonTag` enum maps the same logical tag across iTunes atoms, Vor
 - `ExtendedTags` aggregator across all source apps
 - `MusicalKey` with full Camelot / Open Key / traditional round-tripping
 - `CuePoint`, `LoopPoint`, `BeatGrid`, `Source` enum
-- BPM + key + comment read/write works today (covers Mixed In Key fully)
+- BPM + key + comment read/write works today
+- **Mixed In Key reader** — recovers key/energy/tempo from every documented MIK write location (standard fields, artist/title prefixes+suffixes, comment, grouping, label) and normalises into standard tag fields. `MeedyaMeta:Energy` only when no standard exists.
 - Serato, Rekordbox, Traktor, Virtual DJ proprietary readers pending — each requires fixture-based work against real DJ-tagged files
 
 ### Library import (`meedya-library-import`)

--- a/crates/meedya-core/Cargo.toml
+++ b/crates/meedya-core/Cargo.toml
@@ -8,15 +8,17 @@ repository.workspace = true
 description = "MeedyaSuite-core — unified re-export crate providing the complete MeedyaSuite shared library"
 
 [features]
-default = ["metadata", "codecs", "fingerprint", "lyrics", "providers"]
+default = ["metadata", "codecs", "fingerprint", "lyrics", "providers", "tags-extended", "library-import"]
 metadata = ["dep:meedya-metadata"]
 codecs = ["dep:meedya-codecs"]
 fingerprint = ["dep:meedya-fingerprint"]
 lyrics = ["dep:meedya-lyrics", "metadata"]
 providers = ["dep:meedya-providers"]
 db = ["dep:meedya-db"]
+tags-extended = ["dep:meedya-tags-extended"]
+library-import = ["dep:meedya-library-import"]
 keyring = ["providers", "meedya-providers/keyring-credentials"]
-full = ["metadata", "codecs", "fingerprint", "lyrics", "providers", "db", "keyring"]
+full = ["metadata", "codecs", "fingerprint", "lyrics", "providers", "db", "tags-extended", "library-import", "keyring"]
 
 [dependencies]
 meedya-metadata = { workspace = true, optional = true }
@@ -25,3 +27,5 @@ meedya-fingerprint = { workspace = true, optional = true }
 meedya-lyrics = { workspace = true, optional = true }
 meedya-providers = { workspace = true, optional = true }
 meedya-db = { workspace = true, optional = true }
+meedya-tags-extended = { workspace = true, optional = true }
+meedya-library-import = { workspace = true, optional = true }

--- a/crates/meedya-core/src/lib.rs
+++ b/crates/meedya-core/src/lib.rs
@@ -20,6 +20,10 @@
 //!   pulls in `metadata`)
 //! - `providers` — Provider traits, credentials, rate limiter, match scoring,
 //!   cover art utilities (default)
+//! - `tags-extended` — DJ metadata foundation: `ExtendedTags`, `MusicalKey`,
+//!   `CuePoint`, `BeatGrid`, multi-format tag I/O via lofty (default)
+//! - `library-import` — Ingest playback bounds + metadata from external
+//!   library databases (iTunes XML, CUE sheets) (default)
 //! - `db` — MeedyaDB client scaffolding
 //! - `keyring` — OS keyring credential storage (pulls in `providers`)
 //! - `full` — Everything
@@ -42,6 +46,12 @@ pub use meedya_providers as providers;
 #[cfg(feature = "db")]
 pub use meedya_db as db;
 
+#[cfg(feature = "tags-extended")]
+pub use meedya_tags_extended as tags_extended;
+
+#[cfg(feature = "library-import")]
+pub use meedya_library_import as library_import;
+
 pub mod prelude {
     //! Convenient imports for common types.
 
@@ -61,4 +71,12 @@ pub mod prelude {
 
     #[cfg(feature = "lyrics")]
     pub use meedya_lyrics::{Lyrics, LyricsProvider, SyncedLine, TrackQuery};
+
+    #[cfg(feature = "tags-extended")]
+    pub use meedya_tags_extended::{
+        BeatGrid, CuePoint, ExtendedTags, KeyMode, LoopPoint, MusicalKey, Note, Source, TagFile,
+    };
+
+    #[cfg(feature = "library-import")]
+    pub use meedya_library_import::{EntryLocator, ImportReport, LibraryEntry, SourceInfo};
 }

--- a/crates/meedya-lyrics/Cargo.toml
+++ b/crates/meedya-lyrics/Cargo.toml
@@ -9,6 +9,7 @@ description = "Meedya Core — LRCLIB client, LRC parser/writer, and lyrics writ
 
 [dependencies]
 async-trait = "0.1"
+lofty = { workspace = true }
 meedya-metadata = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/meedya-lyrics/src/embed.rs
+++ b/crates/meedya-lyrics/src/embed.rs
@@ -1,30 +1,146 @@
 //! Embed lyrics into a media file's tag container.
 //!
-//! Writes plain (unsynced) lyrics via `meedya-metadata`'s `CommonTag::Lyrics`,
-//! which maps to the correct atom per format: USLT for ID3v2, `LYRICS` for
-//! Vorbis Comment, `©lyr` for MP4 ilst, etc. Container detection is delegated
-//! to lofty.
+//! Two write targets:
 //!
-//! Synchronized embed (ID3v2 SYLT) is not yet supported — when `lyrics.synced`
-//! is present but `lyrics.plain` is not, the synced lines are flattened to
-//! plain text (one line per stamp, timestamps dropped).
+//! - [`embed`] — plain-text via `meedya-metadata`'s `CommonTag::Lyrics`,
+//!   which maps to the correct atom per format: USLT for ID3v2, `LYRICS`
+//!   for Vorbis Comment, `©lyr` for MP4 ilst. Format detection delegated
+//!   to lofty.
+//! - [`embed_synced`] — ID3v2 SYLT (synchronised lyrics). Only works on
+//!   ID3v2 containers (MP3, optionally WAV/AIFF with an ID3 chunk). For
+//!   other formats (MP4 / Vorbis / FLAC), no widely-supported synchronised
+//!   embed standard exists — this function returns an error and callers
+//!   should fall back to `embed` for plain-text.
+//!
+//! ## Recommended pattern
+//!
+//! ```ignore
+//! // Best-effort: write plain text everywhere, plus SYLT on ID3v2.
+//! let _plain = meedya_lyrics::embed(&path, &lyrics)?;
+//! if lyrics.synced.is_some() {
+//!     // Only succeeds on ID3v2 containers; otherwise ignore the error.
+//!     let _ = meedya_lyrics::embed_synced(&path, &lyrics, b"eng".to_owned());
+//! }
+//! ```
 
+use std::borrow::Cow;
 use std::path::Path;
 
+use lofty::config::WriteOptions;
+use lofty::file::TaggedFile;
+use lofty::id3::v2::{
+    BinaryFrame, Frame, FrameId, Id3v2Tag, SyncTextContentType, SynchronizedTextFrame,
+    TimestampFormat,
+};
+use lofty::prelude::*;
+use lofty::tag::TagType;
+use lofty::TextEncoding;
 use meedya_metadata::{tag_io, CommonTag};
 
-use crate::{Lyrics, Result};
+use crate::{Error, Lyrics, Result};
+
+/// ISO-639-2 language code, three lowercase ASCII letters. Used for SYLT
+/// frame headers when the source lyrics don't carry a language tag.
+pub const DEFAULT_LANGUAGE: [u8; 3] = *b"eng";
 
 /// Embed the plain-text representation of `lyrics` into `media`'s tags.
 ///
 /// Returns `true` if anything was written, `false` if `lyrics` has no
-/// embeddable content.
+/// embeddable content. Synchronised timestamps, if present, are flattened
+/// to plain text. Use [`embed_synced`] alongside this for ID3v2 SYLT.
 pub fn embed(media: &Path, lyrics: &Lyrics) -> Result<bool> {
     let Some(text) = plain_text(lyrics) else {
         return Ok(false);
     };
     tag_io::write_tags(media, &[(CommonTag::Lyrics, text)])?;
     Ok(true)
+}
+
+/// Embed synchronised lyrics (ID3v2 SYLT frame) into `media`.
+///
+/// `lang` is the ISO-639-2 three-letter language code; pass [`DEFAULT_LANGUAGE`]
+/// (`b"eng"`) if unknown. Encoding is UTF-16 with BOM for cross-player
+/// compatibility with non-ASCII text.
+///
+/// Errors if the file is not an ID3v2 container or if `lyrics.synced` is
+/// `None` / empty. Replaces any existing SYLT frame.
+pub fn embed_synced(media: &Path, lyrics: &Lyrics, lang: [u8; 3]) -> Result<()> {
+    let synced = lyrics
+        .synced
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or(Error::NoSyncedLyrics)?;
+
+    if !lang.iter().all(u8::is_ascii_alphabetic) {
+        return Err(Error::InvalidLanguageCode);
+    }
+
+    let mut tagged: TaggedFile = lofty::read_from_path(media)
+        .map_err(|e| Error::Metadata(meedya_metadata::MetadataError::ReadError(e.to_string())))?;
+
+    if !tagged.supports_tag_type(TagType::Id3v2) {
+        return Err(Error::UnsupportedForSync {
+            tag_type: format!("{:?}", tagged.primary_tag_type()),
+        });
+    }
+
+    // Serialize a SynchronizedTextFrame and insert it as a SYLT binary frame.
+    // Lofty doesn't expose SYLT as a Frame enum variant in 0.22, so we go
+    // via bytes — this is the documented escape hatch for less-common frames.
+    let entries: Vec<(u32, String)> = synced
+        .iter()
+        .map(|line| (millis(line), line.text.clone()))
+        .collect();
+
+    let sylt = SynchronizedTextFrame::new(
+        TextEncoding::UTF16,
+        lang,
+        TimestampFormat::MS,
+        SyncTextContentType::Lyrics,
+        None,
+        entries,
+    );
+    let bytes = sylt
+        .as_bytes()
+        .map_err(|e| Error::Metadata(meedya_metadata::MetadataError::WriteError(e.to_string())))?;
+    let frame_id = FrameId::Valid(Cow::Borrowed("SYLT"));
+    let sylt_frame = Frame::Binary(BinaryFrame::new(frame_id.clone(), bytes));
+
+    let id3v2 = match tagged.tag_mut(TagType::Id3v2) {
+        Some(tag) => tag,
+        None => {
+            tagged.insert_tag(lofty::tag::Tag::new(TagType::Id3v2));
+            tagged
+                .tag_mut(TagType::Id3v2)
+                .expect("ID3v2 tag was just inserted")
+        }
+    };
+
+    // Get the underlying Id3v2Tag if possible to use the typed insert; otherwise
+    // fall back to the generic Tag API by removing-and-reinserting via a workaround.
+    // lofty's Tag wraps Id3v2Tag transparently when the tag_type matches, but the
+    // typed API requires us to round-trip through Id3v2Tag::from(&Tag) and back.
+    let mut id3v2_typed = Id3v2Tag::from(std::mem::replace(id3v2, lofty::tag::Tag::new(TagType::Id3v2)));
+    id3v2_typed.remove(&frame_id).for_each(drop);
+    id3v2_typed.insert(sylt_frame);
+    *id3v2 = lofty::tag::Tag::from(id3v2_typed);
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(media)
+        .map_err(|e| Error::Metadata(meedya_metadata::MetadataError::WriteError(e.to_string())))?;
+    let mut file = file;
+    tagged
+        .save_to(&mut file, WriteOptions::default())
+        .map_err(|e| Error::Metadata(meedya_metadata::MetadataError::WriteError(e.to_string())))?;
+
+    Ok(())
+}
+
+fn millis(line: &crate::lyrics::SyncedLine) -> u32 {
+    let ms = line.at.as_millis();
+    u32::try_from(ms).unwrap_or(u32::MAX)
 }
 
 fn plain_text(lyrics: &Lyrics) -> Option<String> {
@@ -112,5 +228,58 @@ mod tests {
     fn embed_empty_lyrics_is_noop() {
         let ok = embed(Path::new("/nonexistent/file.mp3"), &Lyrics::default()).unwrap();
         assert!(!ok);
+    }
+
+    #[test]
+    fn embed_synced_rejects_unsynced() {
+        let lyrics = Lyrics {
+            plain: Some("only plain".into()),
+            synced: None,
+        };
+        let err = embed_synced(Path::new("/nonexistent/file.mp3"), &lyrics, DEFAULT_LANGUAGE)
+            .unwrap_err();
+        assert!(matches!(err, Error::NoSyncedLyrics));
+    }
+
+    #[test]
+    fn embed_synced_rejects_empty_synced() {
+        let lyrics = Lyrics {
+            plain: None,
+            synced: Some(vec![]),
+        };
+        let err = embed_synced(Path::new("/nonexistent/file.mp3"), &lyrics, DEFAULT_LANGUAGE)
+            .unwrap_err();
+        assert!(matches!(err, Error::NoSyncedLyrics));
+    }
+
+    #[test]
+    fn embed_synced_rejects_bad_language_code() {
+        let lyrics = Lyrics {
+            plain: None,
+            synced: Some(vec![SyncedLine {
+                at: Duration::from_millis(0),
+                text: "hi".into(),
+            }]),
+        };
+        let err = embed_synced(Path::new("/nonexistent/file.mp3"), &lyrics, *b"1ng").unwrap_err();
+        assert!(matches!(err, Error::InvalidLanguageCode));
+    }
+
+    #[test]
+    fn millis_clamps_huge_durations() {
+        let line = SyncedLine {
+            at: Duration::from_secs(10_000_000_000), // > u32::MAX ms
+            text: "huge".into(),
+        };
+        assert_eq!(millis(&line), u32::MAX);
+    }
+
+    #[test]
+    fn millis_preserves_small_durations() {
+        let line = SyncedLine {
+            at: Duration::from_millis(12_345),
+            text: "small".into(),
+        };
+        assert_eq!(millis(&line), 12_345);
     }
 }

--- a/crates/meedya-lyrics/src/embed.rs
+++ b/crates/meedya-lyrics/src/embed.rs
@@ -120,7 +120,10 @@ pub fn embed_synced(media: &Path, lyrics: &Lyrics, lang: [u8; 3]) -> Result<()> 
     // fall back to the generic Tag API by removing-and-reinserting via a workaround.
     // lofty's Tag wraps Id3v2Tag transparently when the tag_type matches, but the
     // typed API requires us to round-trip through Id3v2Tag::from(&Tag) and back.
-    let mut id3v2_typed = Id3v2Tag::from(std::mem::replace(id3v2, lofty::tag::Tag::new(TagType::Id3v2)));
+    let mut id3v2_typed = Id3v2Tag::from(std::mem::replace(
+        id3v2,
+        lofty::tag::Tag::new(TagType::Id3v2),
+    ));
     id3v2_typed.remove(&frame_id).for_each(drop);
     id3v2_typed.insert(sylt_frame);
     *id3v2 = lofty::tag::Tag::from(id3v2_typed);
@@ -236,8 +239,12 @@ mod tests {
             plain: Some("only plain".into()),
             synced: None,
         };
-        let err = embed_synced(Path::new("/nonexistent/file.mp3"), &lyrics, DEFAULT_LANGUAGE)
-            .unwrap_err();
+        let err = embed_synced(
+            Path::new("/nonexistent/file.mp3"),
+            &lyrics,
+            DEFAULT_LANGUAGE,
+        )
+        .unwrap_err();
         assert!(matches!(err, Error::NoSyncedLyrics));
     }
 
@@ -247,8 +254,12 @@ mod tests {
             plain: None,
             synced: Some(vec![]),
         };
-        let err = embed_synced(Path::new("/nonexistent/file.mp3"), &lyrics, DEFAULT_LANGUAGE)
-            .unwrap_err();
+        let err = embed_synced(
+            Path::new("/nonexistent/file.mp3"),
+            &lyrics,
+            DEFAULT_LANGUAGE,
+        )
+        .unwrap_err();
         assert!(matches!(err, Error::NoSyncedLyrics));
     }
 

--- a/crates/meedya-lyrics/src/error.rs
+++ b/crates/meedya-lyrics/src/error.rs
@@ -14,9 +14,7 @@ pub enum Error {
     Metadata(#[from] meedya_metadata::MetadataError),
     #[error("synced lyrics requested but none present")]
     NoSyncedLyrics,
-    #[error(
-        "container does not support synchronised lyrics (SYLT is ID3v2-only; got {tag_type})"
-    )]
+    #[error("container does not support synchronised lyrics (SYLT is ID3v2-only; got {tag_type})")]
     UnsupportedForSync { tag_type: String },
     #[error("invalid ISO-639-2 language code (must be 3 ASCII letters)")]
     InvalidLanguageCode,

--- a/crates/meedya-lyrics/src/error.rs
+++ b/crates/meedya-lyrics/src/error.rs
@@ -12,4 +12,12 @@ pub enum Error {
     Lrc(String),
     #[error("metadata: {0}")]
     Metadata(#[from] meedya_metadata::MetadataError),
+    #[error("synced lyrics requested but none present")]
+    NoSyncedLyrics,
+    #[error(
+        "container does not support synchronised lyrics (SYLT is ID3v2-only; got {tag_type})"
+    )]
+    UnsupportedForSync { tag_type: String },
+    #[error("invalid ISO-639-2 language code (must be 3 ASCII letters)")]
+    InvalidLanguageCode,
 }

--- a/crates/meedya-lyrics/src/lib.rs
+++ b/crates/meedya-lyrics/src/lib.rs
@@ -4,11 +4,13 @@
 //! reusable library so MeedyaDL, MeedyaConverter, and MeedyaManager can share
 //! the same lookup, parse, and write code paths.
 //!
-//! Two write targets are supported:
+//! Three write targets are supported:
 //! - [`sidecar::write`] — `.lrc` next to the media file (synced lyrics only).
 //! - [`embed::embed`] — plain-text tag via `meedya-metadata` (USLT for ID3v2,
-//!   `LYRICS` for Vorbis, `©lyr` for MP4). Synchronized ID3v2 SYLT is not
-//!   yet supported.
+//!   `LYRICS` for Vorbis, `©lyr` for MP4).
+//! - [`embed::embed_synced`] — ID3v2 SYLT (synchronised lyrics frame). ID3v2
+//!   containers only; other formats return an error and callers should fall
+//!   back to [`embed::embed`].
 //!
 //! [lrcget]: https://github.com/tranxuanthang/lrcget
 
@@ -19,6 +21,7 @@ pub mod lyrics;
 pub mod provider;
 pub mod sidecar;
 
+pub use embed::{embed, embed_synced, DEFAULT_LANGUAGE};
 pub use error::{Error, Result};
 pub use lyrics::{Lyrics, SyncedLine};
 pub use provider::lrclib::LrclibProvider;

--- a/crates/meedya-tags-extended/src/lib.rs
+++ b/crates/meedya-tags-extended/src/lib.rs
@@ -41,7 +41,10 @@ pub mod model;
 pub mod standard;
 
 pub use io::TagFile;
-pub use mik::{read_mik, normalise_to_standards, MikAnalysis, MikField, MikKinds, MikPosition, MikSourceLocation};
+pub use mik::{
+    normalise_to_standards, read_mik, MikAnalysis, MikField, MikKinds, MikPosition,
+    MikSourceLocation,
+};
 pub use model::{
     BeatGrid, BeatGridMarker, CuePoint, ExtendedTags, KeyMode, LoopPoint, MusicalKey, Note, Rgb,
     Source,

--- a/crates/meedya-tags-extended/src/lib.rs
+++ b/crates/meedya-tags-extended/src/lib.rs
@@ -16,6 +16,12 @@
 // - `io`        — `TagFile`: open/edit/save with foreign-frame preservation.
 // - `standard`  — BPM, key, comment via standard non-proprietary tags.
 //                 Covers Mixed In Key fully (it only writes standard tags).
+// - `mik`       — Mixed In Key reader. Recovers key/energy/tempo from
+//                 every location MIK is documented to write to (standard
+//                 fields, artist/title/comment/grouping/label prefixes,
+//                 suffixes and overwrites), then normalises into standard
+//                 `InitialKey` / `IntegerBpm` / `Bpm` plus
+//                 `MeedyaMeta:Energy` (no standard for energy).
 //
 // ## Future modules (proprietary readers — one per session)
 //
@@ -30,10 +36,12 @@
 // conflict.
 
 pub mod io;
+pub mod mik;
 pub mod model;
 pub mod standard;
 
 pub use io::TagFile;
+pub use mik::{read_mik, normalise_to_standards, MikAnalysis, MikField, MikKinds, MikPosition, MikSourceLocation};
 pub use model::{
     BeatGrid, BeatGridMarker, CuePoint, ExtendedTags, KeyMode, LoopPoint, MusicalKey, Note, Rgb,
     Source,

--- a/crates/meedya-tags-extended/src/mik.rs
+++ b/crates/meedya-tags-extended/src/mik.rs
@@ -273,9 +273,7 @@ fn inspect_combo_field(
             for n in 1..all_tokens.len() {
                 let prefix_tokens = &all_tokens[..n];
                 let parsed = classify_tokens(prefix_tokens);
-                if parsed.kinds.any()
-                    && !leaves_unclassified(prefix_tokens, &parsed.classified)
-                {
+                if parsed.kinds.any() && !leaves_unclassified(prefix_tokens, &parsed.classified) {
                     best = Some(parsed);
                 }
             }
@@ -294,9 +292,7 @@ fn inspect_combo_field(
             for start in (0..all_tokens.len() - 1).rev() {
                 let suffix_tokens = &all_tokens[start + 1..];
                 let parsed = classify_tokens(suffix_tokens);
-                if parsed.kinds.any()
-                    && !leaves_unclassified(suffix_tokens, &parsed.classified)
-                {
+                if parsed.kinds.any() && !leaves_unclassified(suffix_tokens, &parsed.classified) {
                     best = Some(parsed);
                 } else {
                     break;

--- a/crates/meedya-tags-extended/src/mik.rs
+++ b/crates/meedya-tags-extended/src/mik.rs
@@ -1,0 +1,901 @@
+// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Licensed under the MIT License. See LICENSE file in the project root.
+//
+// Mixed In Key reader — recovers MIK's key / energy / tempo from every
+// location MIK is documented to write to, then normalises into standard
+// tag fields. Standards-first by design: writes to ItemKey::InitialKey
+// (TKEY / `----:com.apple.iTunes:initialkey` / INITIALKEY) and
+// ItemKey::IntegerBpm / ItemKey::Bpm (TBPM / tmpo / BPM). Energy has no
+// standard equivalent — only that one field falls back to MeedyaMeta.
+//
+// Source fields are read-only. The reader never modifies the original
+// artist/title/comment/grouping/label strings; the user's data is
+// preserved verbatim. A separate "cleanup" feature could strip MIK
+// prefixes later as an opt-in.
+//
+// ## Locations covered (per MIK Tag options UI)
+//
+// What MIK can write (any combination of key, tempo, energy):
+//   - `10A`              key only
+//   - `Energy 7`         energy with word
+//   - `10A - Energy 7`   key + energy with word
+//   - `7`                energy alone
+//   - `10A - 7`          key + energy
+//   - `10A - 126`        key + tempo
+//   - `10A - 126 - 7`    key + tempo + energy
+//   - `126 - 10A - 7`    tempo + key + energy
+//
+// Where MIK can write:
+//   - In front of artist name      → "10A - Axwell"
+//   - In front of song title       → "10A - Feel the vibe"
+//   - At end of song title         → "Feel the vibe - 10A"
+//   - In front of comments         → "10A - www.beatport.com"
+//   - Overwrite comments           → "10A"
+//   - In front of grouping (energy)→ "Energy 7 - Old skool"
+//   - Overwrite label (energy)     → "Energy 7"
+//   - Standard `InitialKey` field  → "Update custom Initial Key" toggle
+//   - Standard tempo fields        → "Update tempo tags" toggle
+//
+// Camelot zero-padding (`05A` vs `5A`) is handled by `MusicalKey::parse`.
+
+use lofty::tag::{ItemKey, Tag};
+
+use crate::model::MusicalKey;
+use crate::standard;
+
+const MEEDYA_NAMESPACE: &str = "MeedyaMeta";
+const MIK_ENERGY_ATOM: &str = "Energy";
+const MIK_AUDIT_ATOM: &str = "MikSourceLocations";
+
+/// Energy levels above this are unlikely to be MIK output; reject them
+/// as bare-digit energy. MIK uses 1-10.
+const MAX_ENERGY: u8 = 10;
+
+/// BPM range for bare-digit tempo classification. Outside this range, a
+/// bare digit is more likely to be something other than a BPM.
+const MIN_BPM: u32 = 40;
+const MAX_BPM: u32 = 250;
+
+// ============================================================
+// Public Types
+// ============================================================
+
+/// Result of scanning a tag for Mixed In Key output.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MikAnalysis {
+    pub key: Option<MusicalKey>,
+    /// Energy rating (1-10). MIK uses this scale.
+    pub energy: Option<u8>,
+    pub bpm: Option<f64>,
+    /// Where each datapoint came from. The order is the order locations
+    /// were inspected; precedence is "last write wins" within a field
+    /// (standard `InitialKey` is checked first so it loses to any
+    /// embedded-pattern field that follows — which is the right default
+    /// because the embedded fields are typically more recent updates).
+    pub sources: Vec<MikSourceLocation>,
+}
+
+impl MikAnalysis {
+    pub fn is_empty(&self) -> bool {
+        self.key.is_none() && self.energy.is_none() && self.bpm.is_none()
+    }
+}
+
+/// Where a MIK datapoint was extracted from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MikSourceLocation {
+    pub field: MikField,
+    pub position: MikPosition,
+    /// Which datapoints came from this location (one location may
+    /// contribute multiple, e.g., a comment containing `10A - 126 - 7`).
+    pub kinds: MikKinds,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MikField {
+    /// Standard `InitialKey` tag (TKEY / `----:com.apple.iTunes:initialkey` / INITIALKEY).
+    InitialKey,
+    /// Standard BPM tag (TBPM / tmpo / BPM).
+    Bpm,
+    /// Track artist field.
+    Artist,
+    /// Track title field.
+    Title,
+    /// Comment field.
+    Comment,
+    /// Grouping field (ContentGroup ItemKey).
+    Grouping,
+    /// Label / publisher field.
+    Label,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MikPosition {
+    /// The entire field value matched the MIK pattern.
+    Whole,
+    /// The MIK pattern was at the start of the field.
+    Prefix,
+    /// The MIK pattern was at the end of the field.
+    Suffix,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub struct MikKinds {
+    pub key: bool,
+    pub bpm: bool,
+    pub energy: bool,
+}
+
+impl MikKinds {
+    fn any(self) -> bool {
+        self.key || self.bpm || self.energy
+    }
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+/// Scan a tag for everything Mixed In Key may have written and return
+/// the recovered analysis. Does not modify the tag.
+pub fn read_mik(tag: &Tag) -> MikAnalysis {
+    let mut analysis = MikAnalysis::default();
+
+    // Standard fields first — these are unambiguous and lowest-noise.
+    if let Some(key) = standard::read_key(tag) {
+        analysis.key = Some(key);
+        analysis.sources.push(MikSourceLocation {
+            field: MikField::InitialKey,
+            position: MikPosition::Whole,
+            kinds: MikKinds {
+                key: true,
+                ..Default::default()
+            },
+        });
+    }
+    if let Some(bpm) = standard::read_bpm(tag) {
+        analysis.bpm = Some(bpm);
+        analysis.sources.push(MikSourceLocation {
+            field: MikField::Bpm,
+            position: MikPosition::Whole,
+            kinds: MikKinds {
+                bpm: true,
+                ..Default::default()
+            },
+        });
+    }
+
+    // Embedded-pattern fields. Inspect each documented location and let
+    // matches overwrite earlier-discovered values (intentional: a recent
+    // MIK update will appear in these fields after older standard-tag
+    // entries become stale).
+    inspect_combo_field(
+        tag,
+        ItemKey::TrackArtist,
+        MikField::Artist,
+        Some(MikPosition::Prefix),
+        &mut analysis,
+    );
+    inspect_combo_field(
+        tag,
+        ItemKey::TrackTitle,
+        MikField::Title,
+        None,
+        &mut analysis,
+    );
+    inspect_combo_field(
+        tag,
+        ItemKey::Comment,
+        MikField::Comment,
+        None,
+        &mut analysis,
+    );
+    inspect_energy_field(
+        tag,
+        ItemKey::ContentGroup,
+        MikField::Grouping,
+        Some(MikPosition::Prefix),
+        &mut analysis,
+    );
+    inspect_energy_field(
+        tag,
+        ItemKey::Label,
+        MikField::Label,
+        Some(MikPosition::Whole),
+        &mut analysis,
+    );
+
+    analysis
+}
+
+/// Write the recovered analysis into standard tag fields (and one
+/// MeedyaMeta atom for energy, which has no standard equivalent).
+///
+/// Standards used:
+///   - Key → `ItemKey::InitialKey` (TKEY / `----:com.apple.iTunes:initialkey` / INITIALKEY)
+///   - BPM → `ItemKey::IntegerBpm` + `ItemKey::Bpm` (TBPM / tmpo + float on MP4)
+///   - Energy → `MeedyaMeta:Energy` freeform atom (no widely-supported standard)
+///
+/// Also writes `MeedyaMeta:MikSourceLocations` as an audit trail so
+/// downstream tools can see where each datapoint came from.
+pub fn normalise_to_standards(tag: &mut Tag, analysis: &MikAnalysis) {
+    if let Some(key) = analysis.key {
+        standard::write_key(tag, key);
+    }
+    if let Some(bpm) = analysis.bpm {
+        standard::write_bpm(tag, bpm);
+    }
+    if let Some(energy) = analysis.energy {
+        write_meedya_atom(tag, MIK_ENERGY_ATOM, &energy.to_string());
+    }
+    if !analysis.sources.is_empty() {
+        let audit = format_audit_trail(&analysis.sources);
+        write_meedya_atom(tag, MIK_AUDIT_ATOM, &audit);
+    }
+}
+
+// ============================================================
+// Field Inspection
+// ============================================================
+
+/// Inspect a field for MIK's combined key/tempo/energy patterns
+/// (`10A - 126 - 7`, etc.). When `force_position` is `Some`, only that
+/// position is considered; when `None`, prefix and suffix are both tried.
+fn inspect_combo_field(
+    tag: &Tag,
+    item_key: ItemKey,
+    field: MikField,
+    force_position: Option<MikPosition>,
+    analysis: &mut MikAnalysis,
+) {
+    let Some(value) = tag.get_string(&item_key) else {
+        return;
+    };
+
+    // Try whole-field match first.
+    if force_position.is_none() || force_position == Some(MikPosition::Whole) {
+        let tokens = split_dash_tokens(value);
+        let parsed = classify_tokens(&tokens);
+        if parsed.kinds.any() && !leaves_unclassified(&tokens, &parsed.classified) {
+            apply_parsed(analysis, &parsed, field, MikPosition::Whole);
+            return;
+        }
+    }
+
+    // Prefix: greedily consume MIK-classifiable tokens from the start.
+    // The longest classifiable prefix followed by " - " then non-MIK rest
+    // is the match.
+    if force_position.is_none() || force_position == Some(MikPosition::Prefix) {
+        let all_tokens = split_dash_tokens(value);
+        if all_tokens.len() >= 2 {
+            // Find the longest prefix where all tokens classify.
+            let mut best: Option<ParsedTokens> = None;
+            for n in 1..all_tokens.len() {
+                let prefix_tokens = &all_tokens[..n];
+                let parsed = classify_tokens(prefix_tokens);
+                if parsed.kinds.any()
+                    && !leaves_unclassified(prefix_tokens, &parsed.classified)
+                {
+                    best = Some(parsed);
+                }
+            }
+            if let Some(parsed) = best {
+                apply_parsed(analysis, &parsed, field, MikPosition::Prefix);
+                return;
+            }
+        }
+    }
+
+    // Suffix: greedily consume MIK-classifiable tokens from the end.
+    if force_position.is_none() || force_position == Some(MikPosition::Suffix) {
+        let all_tokens = split_dash_tokens(value);
+        if all_tokens.len() >= 2 {
+            let mut best: Option<ParsedTokens> = None;
+            for start in (0..all_tokens.len() - 1).rev() {
+                let suffix_tokens = &all_tokens[start + 1..];
+                let parsed = classify_tokens(suffix_tokens);
+                if parsed.kinds.any()
+                    && !leaves_unclassified(suffix_tokens, &parsed.classified)
+                {
+                    best = Some(parsed);
+                } else {
+                    break;
+                }
+            }
+            if let Some(parsed) = best {
+                apply_parsed(analysis, &parsed, field, MikPosition::Suffix);
+            }
+        }
+    }
+}
+
+/// Inspect a field specifically for energy patterns (`Energy N - ...`
+/// or `Energy N` alone). Used for the grouping and label fields where
+/// MIK only writes energy.
+fn inspect_energy_field(
+    tag: &Tag,
+    item_key: ItemKey,
+    field: MikField,
+    force_position: Option<MikPosition>,
+    analysis: &mut MikAnalysis,
+) {
+    let Some(value) = tag.get_string(&item_key) else {
+        return;
+    };
+
+    let allow_whole = force_position.is_none() || force_position == Some(MikPosition::Whole);
+    let allow_prefix = force_position.is_none() || force_position == Some(MikPosition::Prefix);
+
+    if allow_whole {
+        if let Some(e) = parse_energy_with_word(value.trim()) {
+            analysis.energy = Some(e);
+            analysis.sources.push(MikSourceLocation {
+                field,
+                position: MikPosition::Whole,
+                kinds: MikKinds {
+                    energy: true,
+                    ..Default::default()
+                },
+            });
+            return;
+        }
+    }
+    if allow_prefix {
+        if let Some((prefix, _rest)) = split_at_separator(value) {
+            if let Some(e) = parse_energy_with_word(prefix.trim()) {
+                analysis.energy = Some(e);
+                analysis.sources.push(MikSourceLocation {
+                    field,
+                    position: MikPosition::Prefix,
+                    kinds: MikKinds {
+                        energy: true,
+                        ..Default::default()
+                    },
+                });
+            }
+        }
+    }
+}
+
+// ============================================================
+// Token Classification
+// ============================================================
+
+#[derive(Debug, Default)]
+struct ParsedTokens {
+    key: Option<MusicalKey>,
+    bpm: Option<f64>,
+    energy: Option<u8>,
+    kinds: MikKinds,
+    /// Per-token classified-flag, parallel to the input slice. Used to
+    /// reject candidates that contain unclassified noise.
+    classified: Vec<bool>,
+}
+
+fn classify_tokens(tokens: &[&str]) -> ParsedTokens {
+    let mut out = ParsedTokens::default();
+    out.classified = vec![false; tokens.len()];
+
+    for (i, token) in tokens.iter().enumerate() {
+        let t = token.trim();
+        if t.is_empty() {
+            continue;
+        }
+
+        if let Some(k) = MusicalKey::parse(t) {
+            if out.key.is_none() {
+                out.key = Some(k);
+                out.kinds.key = true;
+                out.classified[i] = true;
+                continue;
+            }
+        }
+        if let Some(e) = parse_energy_with_word(t) {
+            if out.energy.is_none() {
+                out.energy = Some(e);
+                out.kinds.energy = true;
+                out.classified[i] = true;
+                continue;
+            }
+        }
+        if let Some(bpm) = parse_bare_tempo(t) {
+            if out.bpm.is_none() {
+                out.bpm = Some(bpm);
+                out.kinds.bpm = true;
+                out.classified[i] = true;
+                continue;
+            }
+        }
+        if let Some(e) = parse_bare_energy(t) {
+            if out.energy.is_none() {
+                out.energy = Some(e);
+                out.kinds.energy = true;
+                out.classified[i] = true;
+            }
+        }
+    }
+
+    out
+}
+
+fn apply_parsed(
+    analysis: &mut MikAnalysis,
+    parsed: &ParsedTokens,
+    field: MikField,
+    position: MikPosition,
+) {
+    if let Some(k) = parsed.key {
+        analysis.key = Some(k);
+    }
+    if let Some(b) = parsed.bpm {
+        analysis.bpm = Some(b);
+    }
+    if let Some(e) = parsed.energy {
+        analysis.energy = Some(e);
+    }
+    analysis.sources.push(MikSourceLocation {
+        field,
+        position,
+        kinds: parsed.kinds,
+    });
+}
+
+fn leaves_unclassified(tokens: &[&str], classified: &[bool]) -> bool {
+    tokens
+        .iter()
+        .zip(classified.iter())
+        .any(|(t, c)| !c && !t.trim().is_empty())
+}
+
+// ============================================================
+// Token Parsers
+// ============================================================
+
+/// Match `"Energy N"` (case-insensitive on the word). Returns N as 1-10.
+fn parse_energy_with_word(s: &str) -> Option<u8> {
+    let lower = s.to_ascii_lowercase();
+    let rest = lower.strip_prefix("energy")?;
+    let n: u8 = rest.trim().parse().ok()?;
+    (1..=MAX_ENERGY).contains(&n).then_some(n)
+}
+
+/// Match a bare digit in the MIK energy range (1-10).
+fn parse_bare_energy(s: &str) -> Option<u8> {
+    let n: u8 = s.parse().ok()?;
+    (1..=MAX_ENERGY).contains(&n).then_some(n)
+}
+
+/// Match a bare integer in a plausible BPM range (40-250). MIK writes
+/// integer BPMs; we accept floats for future compatibility.
+fn parse_bare_tempo(s: &str) -> Option<f64> {
+    let f: f64 = s.parse().ok()?;
+    if !f.is_finite() {
+        return None;
+    }
+    let i = f as u32;
+    if (MIN_BPM..=MAX_BPM).contains(&i) {
+        Some(f)
+    } else {
+        None
+    }
+}
+
+/// Split a string on `" - "` (space-dash-space) boundaries.
+fn split_dash_tokens(s: &str) -> Vec<&str> {
+    s.split(" - ").collect()
+}
+
+/// Split into `(prefix, rest)` at the first `" - "`. Returns `None` if
+/// no separator is present.
+fn split_at_separator(s: &str) -> Option<(&str, &str)> {
+    s.split_once(" - ")
+}
+
+/// Split into `(rest, suffix)` at the last `" - "`.
+fn split_at_last_separator(s: &str) -> Option<(&str, &str)> {
+    s.rsplit_once(" - ")
+}
+
+// ============================================================
+// MeedyaMeta Atom Writers (energy + audit trail)
+// ============================================================
+
+fn write_meedya_atom(tag: &mut Tag, name: &str, value: &str) {
+    // Lofty's `insert_text` rejects `ItemKey::Unknown` for tag types that
+    // don't recognise the unknown key. We use `insert_unchecked` because
+    // MeedyaMeta atoms are intentionally non-standard — the abstract tag
+    // shouldn't gatekeep them.
+    let item_key = ItemKey::Unknown(format!("----:{MEEDYA_NAMESPACE}:{name}"));
+    tag.insert_unchecked(lofty::tag::TagItem::new(
+        item_key,
+        lofty::tag::ItemValue::Text(value.to_owned()),
+    ));
+}
+
+fn format_audit_trail(sources: &[MikSourceLocation]) -> String {
+    sources
+        .iter()
+        .map(|loc| {
+            let mut tags = Vec::new();
+            if loc.kinds.key {
+                tags.push("key");
+            }
+            if loc.kinds.bpm {
+                tags.push("bpm");
+            }
+            if loc.kinds.energy {
+                tags.push("energy");
+            }
+            format!("{:?}:{:?}({})", loc.field, loc.position, tags.join("+"))
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{KeyMode, Note};
+    use lofty::tag::TagType;
+
+    fn fresh() -> Tag {
+        Tag::new(TagType::Id3v2)
+    }
+
+    /// Camelot 10A is B minor (Bm). Used as the fixture key throughout
+    /// the tests because "10A" is the example MIK uses in its UI.
+    fn bm() -> MusicalKey {
+        MusicalKey {
+            tonic: Note::B,
+            mode: KeyMode::Minor,
+        }
+    }
+
+    // ---- Token classification ----
+
+    #[test]
+    fn token_classify_key_only() {
+        let p = classify_tokens(&["10A"]);
+        assert_eq!(p.key, Some(bm()));
+        assert_eq!(p.bpm, None);
+        assert_eq!(p.energy, None);
+    }
+
+    #[test]
+    fn token_classify_zero_padded_camelot() {
+        let p = classify_tokens(&["05A"]);
+        let k = p.key.expect("parses 05A");
+        assert_eq!(k.camelot(), "5A");
+    }
+
+    #[test]
+    fn token_classify_traditional_flat() {
+        let p = classify_tokens(&["Bbm"]);
+        assert_eq!(p.key.map(|k| k.traditional()), Some("A#m".to_owned()));
+    }
+
+    #[test]
+    fn token_classify_traditional_sharp() {
+        let p = classify_tokens(&["F#m"]);
+        assert!(p.key.is_some());
+    }
+
+    #[test]
+    fn token_classify_key_and_tempo() {
+        let p = classify_tokens(&["10A", "126"]);
+        assert_eq!(p.key, Some(bm()));
+        assert_eq!(p.bpm, Some(126.0));
+    }
+
+    #[test]
+    fn token_classify_key_tempo_energy() {
+        let p = classify_tokens(&["10A", "126", "7"]);
+        assert_eq!(p.key, Some(bm()));
+        assert_eq!(p.bpm, Some(126.0));
+        assert_eq!(p.energy, Some(7));
+    }
+
+    #[test]
+    fn token_classify_tempo_key_energy() {
+        let p = classify_tokens(&["126", "10A", "7"]);
+        assert_eq!(p.key, Some(bm()));
+        assert_eq!(p.bpm, Some(126.0));
+        assert_eq!(p.energy, Some(7));
+    }
+
+    #[test]
+    fn token_classify_energy_with_word() {
+        let p = classify_tokens(&["Energy 7"]);
+        assert_eq!(p.energy, Some(7));
+    }
+
+    #[test]
+    fn token_classify_key_and_energy_word() {
+        let p = classify_tokens(&["10A", "Energy 7"]);
+        assert_eq!(p.key, Some(bm()));
+        assert_eq!(p.energy, Some(7));
+    }
+
+    #[test]
+    fn token_classify_bare_energy_only() {
+        let p = classify_tokens(&["7"]);
+        assert_eq!(p.energy, Some(7));
+        assert_eq!(p.bpm, None);
+    }
+
+    #[test]
+    fn token_classify_key_and_bare_energy() {
+        let p = classify_tokens(&["10A", "7"]);
+        assert_eq!(p.key, Some(bm()));
+        assert_eq!(p.energy, Some(7));
+        assert_eq!(p.bpm, None);
+    }
+
+    #[test]
+    fn token_classify_rejects_unrelated_token() {
+        let p = classify_tokens(&["10A", "www.beatport.com"]);
+        // Key recovered, but unclassified token leaves remnants.
+        assert_eq!(p.key, Some(bm()));
+        assert!(leaves_unclassified(
+            &["10A", "www.beatport.com"],
+            &p.classified
+        ));
+    }
+
+    // ---- Field inspection ----
+
+    #[test]
+    fn read_initial_key_only() {
+        let mut tag = fresh();
+        standard::write_key(&mut tag, bm());
+        let a = read_mik(&tag);
+        assert_eq!(a.key, Some(bm()));
+        assert_eq!(a.sources.len(), 1);
+        assert_eq!(a.sources[0].field, MikField::InitialKey);
+    }
+
+    #[test]
+    fn read_bpm_only() {
+        let mut tag = fresh();
+        standard::write_bpm(&mut tag, 126.0);
+        let a = read_mik(&tag);
+        assert_eq!(a.bpm, Some(126.0));
+    }
+
+    #[test]
+    fn read_artist_prefix() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::TrackArtist, "10A - Axwell".to_owned());
+        let a = read_mik(&tag);
+        assert_eq!(a.key, Some(bm()));
+        let src = a
+            .sources
+            .iter()
+            .find(|s| s.field == MikField::Artist)
+            .expect("artist source");
+        assert_eq!(src.position, MikPosition::Prefix);
+    }
+
+    #[test]
+    fn read_title_prefix() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::TrackTitle, "10A - Feel the vibe".to_owned());
+        let a = read_mik(&tag);
+        assert_eq!(a.key, Some(bm()));
+    }
+
+    #[test]
+    fn read_title_suffix() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::TrackTitle, "Feel the vibe - 10A".to_owned());
+        let a = read_mik(&tag);
+        assert_eq!(a.key, Some(bm()));
+        let src = a
+            .sources
+            .iter()
+            .find(|s| s.field == MikField::Title)
+            .expect("title source");
+        assert_eq!(src.position, MikPosition::Suffix);
+    }
+
+    #[test]
+    fn read_comment_prefix() {
+        let mut tag = fresh();
+        tag.insert_text(
+            ItemKey::Comment,
+            "10A - 126 - 7 - www.beatport.com".to_owned(),
+        );
+        let a = read_mik(&tag);
+        assert_eq!(a.key, Some(bm()));
+        assert_eq!(a.bpm, Some(126.0));
+        assert_eq!(a.energy, Some(7));
+    }
+
+    #[test]
+    fn read_comment_overwrite() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::Comment, "10A".to_owned());
+        let a = read_mik(&tag);
+        assert_eq!(a.key, Some(bm()));
+        let src = a
+            .sources
+            .iter()
+            .find(|s| s.field == MikField::Comment)
+            .expect("comment source");
+        assert_eq!(src.position, MikPosition::Whole);
+    }
+
+    #[test]
+    fn read_grouping_energy_prefix() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::ContentGroup, "Energy 7 - Old skool".to_owned());
+        let a = read_mik(&tag);
+        assert_eq!(a.energy, Some(7));
+    }
+
+    #[test]
+    fn read_label_energy_whole() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::Label, "Energy 7".to_owned());
+        let a = read_mik(&tag);
+        assert_eq!(a.energy, Some(7));
+    }
+
+    #[test]
+    fn read_label_non_mik_ignored() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::Label, "Some Records".to_owned());
+        let a = read_mik(&tag);
+        assert_eq!(a.energy, None);
+    }
+
+    #[test]
+    fn read_artist_without_mik_pattern_ignored() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::TrackArtist, "Just Some Artist".to_owned());
+        let a = read_mik(&tag);
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn read_artist_with_garbage_after_key_ignored() {
+        // "10A - random_junk" — key looks present but the second token
+        // isn't classifiable. Reject as a false positive on the prefix
+        // by requiring all tokens in the matched segment to classify.
+        let mut tag = fresh();
+        tag.insert_text(
+            ItemKey::TrackArtist,
+            "10A - random_unclassifiable".to_owned(),
+        );
+        let a = read_mik(&tag);
+        // Artist prefix uses split_at_separator; the prefix is just "10A"
+        // (single token, classifies) so the read should succeed for key
+        // only. The unclassifiable rest is naturally the artist remainder.
+        assert_eq!(a.key, Some(bm()));
+    }
+
+    // ---- Normalisation ----
+
+    #[test]
+    fn normalise_writes_standard_key() {
+        let mut tag = fresh();
+        let analysis = MikAnalysis {
+            key: Some(bm()),
+            bpm: Some(128.0),
+            energy: Some(8),
+            sources: vec![MikSourceLocation {
+                field: MikField::Artist,
+                position: MikPosition::Prefix,
+                kinds: MikKinds {
+                    key: true,
+                    bpm: true,
+                    energy: true,
+                },
+            }],
+        };
+        normalise_to_standards(&mut tag, &analysis);
+
+        assert_eq!(standard::read_key(&tag), Some(bm()));
+        assert_eq!(standard::read_bpm(&tag), Some(128.0));
+        // Energy lives in MeedyaMeta:Energy — verify via raw atom read.
+        let energy_key = ItemKey::Unknown(format!("----:{MEEDYA_NAMESPACE}:{MIK_ENERGY_ATOM}"));
+        assert_eq!(tag.get_string(&energy_key), Some("8"));
+        // Audit trail present.
+        let audit_key = ItemKey::Unknown(format!("----:{MEEDYA_NAMESPACE}:{MIK_AUDIT_ATOM}"));
+        assert!(tag.get_string(&audit_key).is_some());
+    }
+
+    #[test]
+    fn normalise_skips_unset_fields() {
+        let mut tag = fresh();
+        let analysis = MikAnalysis {
+            key: None,
+            bpm: None,
+            energy: Some(5),
+            sources: vec![],
+        };
+        normalise_to_standards(&mut tag, &analysis);
+        assert_eq!(standard::read_key(&tag), None);
+        assert_eq!(standard::read_bpm(&tag), None);
+        let energy_key = ItemKey::Unknown(format!("----:{MEEDYA_NAMESPACE}:{MIK_ENERGY_ATOM}"));
+        assert_eq!(tag.get_string(&energy_key), Some("5"));
+    }
+
+    #[test]
+    fn round_trip_comment_then_normalise() {
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::Comment, "10A - 126 - 7".to_owned());
+
+        let analysis = read_mik(&tag);
+        normalise_to_standards(&mut tag, &analysis);
+
+        // Standard fields now populated.
+        assert_eq!(standard::read_key(&tag), Some(bm()));
+        assert_eq!(standard::read_bpm(&tag), Some(126.0));
+        // Original comment preserved.
+        assert_eq!(tag.get_string(&ItemKey::Comment), Some("10A - 126 - 7"));
+    }
+
+    // ---- Edge cases ----
+
+    #[test]
+    fn empty_tag_yields_empty_analysis() {
+        let tag = fresh();
+        let a = read_mik(&tag);
+        assert!(a.is_empty());
+        assert!(a.sources.is_empty());
+    }
+
+    #[test]
+    fn energy_out_of_range_rejected() {
+        assert_eq!(parse_energy_with_word("Energy 99"), None);
+        assert_eq!(parse_bare_energy("99"), None);
+    }
+
+    #[test]
+    fn bpm_out_of_range_rejected() {
+        assert_eq!(parse_bare_tempo("30"), None);
+        assert_eq!(parse_bare_tempo("999"), None);
+    }
+
+    #[test]
+    fn separator_is_space_dash_space_only() {
+        // Not a MIK separator without spaces around the dash.
+        let mut tag = fresh();
+        tag.insert_text(ItemKey::TrackTitle, "10A-Feel".to_owned());
+        let a = read_mik(&tag);
+        assert!(a.is_empty(), "no spaces around dash means no MIK pattern");
+    }
+
+    #[test]
+    fn sources_audit_format() {
+        let sources = vec![
+            MikSourceLocation {
+                field: MikField::Comment,
+                position: MikPosition::Prefix,
+                kinds: MikKinds {
+                    key: true,
+                    bpm: true,
+                    energy: true,
+                },
+            },
+            MikSourceLocation {
+                field: MikField::Label,
+                position: MikPosition::Whole,
+                kinds: MikKinds {
+                    energy: true,
+                    ..Default::default()
+                },
+            },
+        ];
+        let audit = format_audit_trail(&sources);
+        assert!(audit.contains("Comment"));
+        assert!(audit.contains("Prefix"));
+        assert!(audit.contains("key+bpm+energy"));
+        assert!(audit.contains("Label"));
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,7 @@
 >
 > **This is not a Swagger/OpenAPI spec.** `MeedyaSuite-core` is a Rust library workspace, not a web service. There are no HTTP endpoints. If you need an HTTP-shaped contract, build one in your downstream app on top of these crates.
 >
-> **Last refreshed**: 2026-05-18. See the [maintenance section](#maintenance) for how this stays in sync with the code.
+> **Last refreshed**: 2026-05-18 (post issues #26 SYLT + #27 facade re-exports + #31 Mixed In Key reader). See the [maintenance section](#maintenance) for how this stays in sync with the code.
 
 ---
 
@@ -37,16 +37,16 @@ All crates are workspace members at `crates/<name>/`. Edition 2021, MIT licensed
 | Crate | Public modules | Tests | Stability |
 |---|---|---|---|
 | `meedya-codecs` | `audio_codec`, `channel_config`, `classify`, `container`, `ffprobe`, `hdr`, `mediainfo`, `registry`, `spatial`, `spatial_type`, `subtitle_codec`, `tool_path`, `video_codec` | 47 | Stable for partner-app consumption |
-| `meedya-core` | (facade re-exports only) | 0 | Stable |
+| `meedya-core` | (facade re-exports only — `tags-extended` and `library-import` now included) | 0 | Stable |
 | `meedya-db` | `client`, `export`, `models` | 3 | Foundation stable; specific endpoints may evolve |
 | `meedya-fingerprint` | `acoustid`, `replaygain` | 6 | Stable |
 | `meedya-library-import` | `cuesheet`, `itunes_xml` | 30 | Stable |
-| `meedya-lyrics` | `embed`, `lrc`, `lyrics`, `provider`, `sidecar` | 10 | Stable |
+| `meedya-lyrics` | `embed`, `lrc`, `lyrics`, `provider`, `sidecar` | 15 | Stable (plain + synced via SYLT for ID3v2) |
 | `meedya-metadata` | `codec_tags`, `common_tags`, `json_path`, `playback_bounds`, `registry`, `tag_io`, `tag_registry`, `writer` | 59 | Stable (two co-existing surfaces) |
 | `meedya-providers` | `cover_art`, `credentials`, `match_scoring`, `rate_limiter`, `traits`, `types` | 27 | Stable foundation; specific provider implementations may evolve |
-| `meedya-tags-extended` | `io`, `model`, `standard` | 29 | Foundation stable; proprietary DJ readers pending |
+| `meedya-tags-extended` | `io`, `mik`, `model`, `standard` | 61 | Foundation stable + Mixed In Key reader; other proprietary DJ readers pending |
 
-**Total: 211 tests.** All passing on `main`.
+**Total: 248 tests.** All passing on the feature branch (211 → 248 this batch).
 
 ---
 
@@ -111,6 +111,8 @@ Unified facade crate that re-exports the other implemented crates behind feature
 | `fingerprint` | `meedya-fingerprint` | ✓ |
 | `lyrics` | `meedya-lyrics` (+ `metadata`) | ✓ |
 | `providers` | `meedya-providers` | ✓ |
+| `tags-extended` | `meedya-tags-extended` | ✓ |
+| `library-import` | `meedya-library-import` | ✓ |
 | `db` | `meedya-db` |  |
 | `keyring` | OS keyring (pulls `providers`) |  |
 | `full` | Everything |  |
@@ -124,6 +126,8 @@ pub use meedya_fingerprint as fingerprint;
 pub use meedya_lyrics as lyrics;
 pub use meedya_providers as providers;
 pub use meedya_db as db;
+pub use meedya_tags_extended as tags_extended;
+pub use meedya_library_import as library_import;
 ```
 
 #### `meedya_core::prelude`
@@ -135,9 +139,11 @@ pub use meedya_codecs::{AudioCodec, ChannelConfig, CodecRegistry, ContainerForma
 pub use meedya_providers::{CredentialStore, MetadataProvider, ProviderCapabilities,
                             ProviderRateLimiter, ProviderResult, SearchQuery};
 pub use meedya_lyrics::{Lyrics, LyricsProvider, SyncedLine, TrackQuery};
+pub use meedya_tags_extended::{
+    BeatGrid, CuePoint, ExtendedTags, KeyMode, LoopPoint, MusicalKey, Note, Source, TagFile,
+};
+pub use meedya_library_import::{EntryLocator, ImportReport, LibraryEntry, SourceInfo};
 ```
-
-> **Note**: `meedya-tags-extended` and `meedya-library-import` are not yet re-exported through `meedya-core`. Consume them directly until a feature flag is added.
 
 ---
 
@@ -264,6 +270,7 @@ LRCLIB client, LRC parser/writer, sidecar + tag-embed writes.
 #### Public re-exports
 
 ```rust
+pub use embed::{embed, embed_synced, DEFAULT_LANGUAGE};
 pub use error::{Error, Result};
 pub use lyrics::{Lyrics, SyncedLine};
 pub use provider::lrclib::LrclibProvider;
@@ -298,7 +305,9 @@ Implementation: `LrclibProvider` (calls lrclib.net).
 #### Write targets
 
 - **`sidecar::write(lyrics: &Lyrics, target_path: &Path) -> Result<()>`** — writes a `.lrc` file next to the source media.
-- **`embed::embed(...)`** — plain-text tag-embed via `meedya-metadata` (USLT for ID3v2, `LYRICS` for Vorbis, `©lyr` for MP4). Synchronised ID3v2 SYLT is **not yet** supported.
+- **`embed::embed(media: &Path, lyrics: &Lyrics) -> Result<bool>`** — plain-text tag-embed via `meedya-metadata` (USLT for ID3v2, `LYRICS` for Vorbis, `©lyr` for MP4).
+- **`embed::embed_synced(media: &Path, lyrics: &Lyrics, lang: [u8; 3]) -> Result<()>`** — synchronised ID3v2 SYLT frame. ID3v2-only by design; errors with `Error::UnsupportedForSync` on other formats. Encoding: UTF-16 with BOM; timestamp format: milliseconds. Recommended pattern: call both `embed()` and `embed_synced()` — the former handles cross-format plain text, the latter adds SYLT where applicable.
+- **`embed::DEFAULT_LANGUAGE`** — `*b"eng"`, the ISO-639-2 default for callers without a known language code.
 
 #### `lrc` module
 
@@ -432,6 +441,10 @@ Multi-format tag I/O foundation with DJ metadata support. Built on `lofty`. Desi
 
 ```rust
 pub use io::TagFile;
+pub use mik::{
+    read_mik, normalise_to_standards,
+    MikAnalysis, MikField, MikKinds, MikPosition, MikSourceLocation,
+};
 pub use model::{
     BeatGrid, BeatGridMarker, CuePoint, ExtendedTags, KeyMode,
     LoopPoint, MusicalKey, Note, Rgb, Source,
@@ -496,7 +509,7 @@ impl MusicalKey {
 
 #### `standard` module
 
-BPM / key / comment read+write across all `lofty`-supported formats. Covers Mixed In Key fully (MIK writes only standard tags).
+BPM / key / comment read+write across all `lofty`-supported formats.
 
 ```rust
 pub fn read_bpm(tag: &Tag) -> Option<f64>;
@@ -512,7 +525,49 @@ pub fn write_comment(tag: &mut Tag, value: String);
 pub fn clear_comment(tag: &mut Tag);
 ```
 
-#### Pending (foundation only; not yet implemented)
+#### `mik` module — Mixed In Key reader
+
+Recovers MIK's key / energy / tempo from every location MIK is documented to write to (standard fields, artist/title prefixes and suffixes, comment, grouping, label) and normalises into standard tag fields. Standards-first by design — only Energy falls back to `MeedyaMeta:Energy` because no widely-supported standard exists for it.
+
+```rust
+pub fn read_mik(tag: &Tag) -> MikAnalysis;
+pub fn normalise_to_standards(tag: &mut Tag, analysis: &MikAnalysis);
+
+pub struct MikAnalysis {
+    pub key: Option<MusicalKey>,
+    pub energy: Option<u8>,        // 1-10
+    pub bpm: Option<f64>,
+    pub sources: Vec<MikSourceLocation>,
+}
+
+pub struct MikSourceLocation {
+    pub field: MikField,
+    pub position: MikPosition,
+    pub kinds: MikKinds,
+}
+pub enum MikField { InitialKey, Bpm, Artist, Title, Comment, Grouping, Label }
+pub enum MikPosition { Whole, Prefix, Suffix }
+pub struct MikKinds { pub key: bool, pub bpm: bool, pub energy: bool }
+```
+
+**Normalisation** writes:
+
+- Key → `ItemKey::InitialKey` (TKEY / `----:com.apple.iTunes:initialkey` / INITIALKEY)
+- BPM → `ItemKey::IntegerBpm` + `ItemKey::Bpm` (TBPM / tmpo / BPM)
+- Energy → `MeedyaMeta:Energy` (no standard exists)
+- Audit trail → `MeedyaMeta:MikSourceLocations` (which location each datapoint came from)
+
+Source fields (Artist/Title/Comment/Grouping/Label) are **read-only**; the original strings are preserved verbatim. A separate opt-in cleanup pass could strip MIK prefixes later.
+
+**Token classification** (greedy prefix/suffix matching):
+
+- Camelot/OpenKey/traditional (with sharps OR flats) → key. Zero-padded `05A` supported.
+- `"Energy N"` (case-insensitive) → energy (1-10).
+- Bare integer 1-10 → energy.
+- Bare integer 40-250 → tempo.
+- `" - "` (space-dash-space) is the separator. `"10A-Feel"` (no spaces) is NOT classified as MIK.
+
+#### Pending (proprietary readers, fixture-driven)
 
 `serato`, `rekordbox`, `traktor`, `virtualdj` modules. Each will be implemented in its own focused session against real DJ-tagged fixture files. See [`.claude/PROMPTS.md`](../.claude/PROMPTS.md#implementing-a-proprietary-dj-reader) for the procedure and guardrails.
 
@@ -580,11 +635,36 @@ pub fn clear_comment(tag: &mut Tag);
 ### Read DJ metadata from a file
 
 ```text
-1. let tag_file = meedya_tags_extended::TagFile::open(&path)?;
-2. let tag      = tag_file.primary_tag().ok_or(...)?
-3. let bpm      = meedya_tags_extended::standard::read_bpm(tag);
-4. let key      = meedya_tags_extended::standard::read_key(tag);
+1. let mut tag_file = meedya_tags_extended::TagFile::open(&path)?;
+2. let tag         = tag_file.primary_tag().ok_or(...)?;
+3. let bpm         = meedya_tags_extended::standard::read_bpm(tag);
+4. let key         = meedya_tags_extended::standard::read_key(tag);
 5. (Future) let serato_data = meedya_tags_extended::serato::read(&tag_file)?;
+```
+
+### Recover Mixed In Key analysis and normalise to standard tags
+
+```text
+1. let mut tag_file = meedya_tags_extended::TagFile::open(&path)?;
+2. let analysis = meedya_tags_extended::read_mik(tag_file.primary_tag().unwrap());
+3. // Inspect analysis.key / .bpm / .energy / .sources for UI display, etc.
+4. meedya_tags_extended::normalise_to_standards(tag_file.primary_tag_mut(), &analysis);
+5. tag_file.save()?;
+// Result: standard InitialKey + IntegerBpm + Bpm now populated regardless of
+// where MIK originally wrote the data (e.g., comment prefix "10A - 126 - 7").
+// MeedyaMeta:Energy carries the energy rating (no standard for that field).
+// Original source fields (artist/title/comment/etc.) are NOT modified.
+```
+
+### Embed lyrics with both plain text and synchronised SYLT (MP3)
+
+```text
+1. let lyrics = LrclibProvider::new().fetch(&query).await?.unwrap();
+2. let _ = meedya_lyrics::embed(&path, &lyrics)?;     // USLT/©lyr/LYRICS
+3. if lyrics.synced.is_some() {
+       // SYLT — succeeds on ID3v2 (MP3) only; ignore Error::UnsupportedForSync.
+       let _ = meedya_lyrics::embed_synced(&path, &lyrics, meedya_lyrics::DEFAULT_LANGUAGE);
+   }
 ```
 
 ---
@@ -594,7 +674,7 @@ pub fn clear_comment(tag: &mut Tag);
 | Tier | Crates | Compatibility guarantee |
 |---|---|---|
 | **Stable** | `meedya-codecs`, `meedya-core`, `meedya-fingerprint`, `meedya-library-import`, `meedya-lyrics`, `meedya-metadata`, `meedya-providers` | Public APIs follow semver; breaking changes get a major-version bump. Foundation types (`AudioCodec`, `ContainerFormat`, `CommonTag`, `Track`/`Album`/`Artist`) are particularly stable. |
-| **Foundation stable** | `meedya-tags-extended` | Core types (`ExtendedTags`, `MusicalKey`, `CuePoint`) are stable. Proprietary reader modules (`serato`, `rekordbox`, `traktor`, `virtualdj`) are not yet implemented — when added, they will populate the existing `ExtendedTags` shape, not change it. |
+| **Foundation stable + MIK reader** | `meedya-tags-extended` | Core types (`ExtendedTags`, `MusicalKey`, `CuePoint`) and the Mixed In Key reader (`read_mik`, `normalise_to_standards`, `MikAnalysis`) are stable. Other proprietary reader modules (`serato`, `rekordbox`, `traktor`, `virtualdj`) are not yet implemented — when added, they will populate the existing `ExtendedTags` shape, not change it. |
 | **Experimental** | (none currently) | — |
 
 All crates share workspace `version = "0.1.0"`. Pre-1.0, minor-version bumps may include breaking changes; please pin to a git revision or tag in downstream apps until 1.0.


### PR DESCRIPTION
Batches three implemented issues + the foundational standards-first design principle into a single release. Workspace tests **211 → 248** (+37). All passing, builds clean across `--no-default-features`, default features, and `--features full`.

## Closes

- Closes #26 — `meedya-lyrics`: synchronised ID3v2 SYLT writer
- Closes #27 — `meedya-core`: re-export `meedya-tags-extended` + `meedya-library-import`
- Closes #31 — `meedya-tags-extended`: Mixed In Key reader with standards-first normalisation

## What's in this batch

### `meedya-core` facade — re-exports + feature flags (#27, `db98b89`)
- New feature flags `tags-extended` and `library-import`, both in `default` and `full`.
- Re-exports `meedya_tags_extended as tags_extended` and `meedya_library_import as library_import`.
- `meedya_core::prelude` extended with `TagFile`, `ExtendedTags`, `MusicalKey`, `KeyMode`, `Note`, `CuePoint`, `LoopPoint`, `BeatGrid`, `Source`, `LibraryEntry`, `EntryLocator`, `ImportReport`, `SourceInfo`.
- Workspace `Cargo.toml` registers both crates so the facade can resolve them via `workspace = true`.

### `meedya-lyrics` — SYLT support (#26, `77762e3`)
- `embed_synced(media, lyrics, lang) -> Result<()>` writes ID3v2 SYLT frames.
- Errors with `Error::UnsupportedForSync { tag_type }` on non-ID3v2 containers (MP4 / Vorbis / FLAC have no widely-supported synchronised-lyrics standard).
- UTF-16 with BOM encoding, millisecond timestamp format, `SyncTextContentType::Lyrics`.
- Replaces any existing SYLT frame on the file; preserves all other frames.
- New `DEFAULT_LANGUAGE` constant (`*b\"eng\"`) for callers without a specific ISO-639-2 code.
- Three new `Error` variants: `NoSyncedLyrics`, `UnsupportedForSync`, `InvalidLanguageCode`.
- Implementation goes via `SynchronizedTextFrame::as_bytes()` → `BinaryFrame` (lofty 0.22 doesn't expose SYLT as a first-class Frame variant; this is the documented escape hatch).

### `meedya-tags-extended` — Mixed In Key reader (#31, `b501104`)
Recovers MIK's key / energy / tempo from every location MIK is documented to write to, then normalises into standard tag fields.

**Locations scanned** (all 8 \"what to write\" × 7 \"where to write\" combinations from MIK's UI):
- Standard `InitialKey` and `IntegerBpm` / `Bpm`
- Artist field prefix: `\"10A - Axwell\"`
- Title field prefix and suffix: `\"10A - Feel the vibe\"` / `\"Feel the vibe - 10A\"`
- Comment field: whole-field, prefix, suffix (`\"10A - 126 - 7 - www.beatport.com\"` recovers all three datapoints and leaves the URL untouched)
- Grouping field energy prefix: `\"Energy 7 - Old skool\"`
- Label field energy whole-match: `\"Energy 7\"`

**Standards-first normalisation**:
- Key → `ItemKey::InitialKey` (TKEY / `----:com.apple.iTunes:initialkey` / INITIALKEY)
- BPM → `ItemKey::IntegerBpm` + `ItemKey::Bpm` (TBPM / tmpo / BPM with float precision on MP4)
- Energy → `MeedyaMeta:Energy` — **the only field that falls back to MeedyaMeta**, because no widely-supported standard exists for energy ratings
- Audit trail → `MeedyaMeta:MikSourceLocations`

**Source fields are read-only.** Original artist/title/comment/grouping/label strings preserved verbatim. A separate cleanup pass could opt-in to stripping MIK prefixes later.

### Standards-first design principle (added to `.claude/CLAUDE.md`)
Per user direction: standards-first across the entire project, not just MIK. Use standard metadata tags (ID3v2 / Vorbis / MP4 ilst spec fields) wherever they exist. Fall back to `MeedyaMeta:*` freeform atoms only when no standard equivalent exists. This is now design principle #1.

### Documentation refresh (`6da100b`)
- `docs/API.md`: workspace overview test counts updated; new `mik` module section in tags-extended; SYLT in meedya-lyrics; two new common-workflow examples; stability tier updates.
- `.claude/CONTEXT.md`: refreshed crate table, MIK in tags-extended description, standards-first as design decision #0.
- `.claude/CLAUDE.md`: standards-first added as design principle #1.
- `.claude/HISTORY.md`: appended detailed session entry.
- `README.md`: 211 → 248 test count, MIK reader mentioned, SYLT mentioned.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo build -p meedya-core --no-default-features` — clean
- [x] `cargo build -p meedya-core --features full` — clean
- [x] `cargo test --workspace` — **248 tests passing** (37 new this batch)
- [ ] CI status checks (Backend + Frontend) — will run on PR
- [ ] Manual smoke test of SYLT round-trip against a real MP3 — deferred to fixture-based work
- [ ] Team review of:
  - The standards-first principle adoption (affects all future tag work)
  - MIK token-classification heuristics (greedy prefix/suffix matching; \" - \" separator requirement)
  - MIK fallback to `MeedyaMeta:Energy` (no standard exists; alternative would be writing `\"Energy 7\"` to comment field — rejected because it noisy-modifies user data)

## Commits

| SHA | Title | Tests +/- |
|---|---|---|
| `db98b89` | feat(meedya-core): re-export meedya-tags-extended and meedya-library-import | +0 |
| `77762e3` | feat(meedya-lyrics): implement synchronised ID3v2 SYLT writer | +5 |
| `b501104` | feat(meedya-tags-extended): Mixed In Key reader with standards-first normalisation | +32 |
| `6da100b` | docs: refresh API.md, CONTEXT.md, CLAUDE.md, HISTORY.md, README for the batch | — |

## Intentionally NOT in this batch

Issues #21-#24 (Serato / Rekordbox / Traktor / VirtualDJ proprietary readers), #25 (chapters crate), #28 (Swift bindings), #29 (WASM bindings), #30 (CI stale-API check). Each was honestly assessed against guardrails before deferring:

- **DJ proprietary readers (#21-#24)**: explicitly require real DJ-tagged fixture files per the issue bodies and `.claude/PROMPTS.md` — \"DO NOT reverse-engineer from memory\". Will land in their own focused sessions when fixtures are available.
- **Chapters crate (#25)**: \"Large\" complexity; needs a prototype phase to choose between mp4ameta / mp4parse-rust / bento4 / hand-written atom emitters.
- **Swift bindings (#28)**: \"Large\" complexity; cbindgen vs uniffi decision best made with the MeedyaConverter team.
- **WASM bindings (#29)**: \"Medium\" complexity; needs scope decisions about browser CORS / no-filesystem constraints.
- **CI stale-API.md check (#30)**: workflow YAML needs PR-cycle iteration to validate; committing untested CI from a single session is risky.

Each deferred issue remains open with its full spec for future work.

## Notable observation worth flagging

The repo's `.gitignore` had an accidental `No` typo appended (no newline, looks like fat-fingered IDE keystroke) — left **unstaged** rather than included in this PR. You may want to clean it up on `main` or via a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)