### PR TITLE
chore(copyright): normalise to "Copyright (c) 2026 MeedyaSuite"

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,7 +26,7 @@ Rust workspace, 9 crates, 211 tests passing. Two co-existing tag-I/O foundations
 
 - **Copyright header** on every source file:
   ```
-  // Copyright (c) 2024-2026 MWBM Partners Ltd
+  // Copyright (c) 2026 MeedyaSuite
   // Licensed under the MIT License. See LICENSE file in the project root.
   ```
 - **Module documentation**: comment block explaining purpose, source (which downstream app it was extracted from, if any), and consumers.

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -114,7 +114,7 @@ cargo test  -p meedya-metadata   # single crate
 cargo doc   --workspace --no-deps --open  # exhaustive auto-generated reference
 ```
 
-Workspace uses Rust edition 2021, MIT license, copyright header `// Copyright (c) 2024-2026 MWBM Partners Ltd` on new source files (older files retain `// Copyright (c) 2026 MWBMPartners`).
+Workspace uses Rust edition 2021, MIT license, copyright header `// Copyright (c) 2026 MeedyaSuite` on new source files (older files retain `// Copyright (c) 2026 MeedyaSuite`).
 
 ## Cross-repo coordination
 

--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -18,7 +18,7 @@
 Every Rust source file starts with:
 
 ```rust
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 ```
 
@@ -27,7 +27,7 @@ Every Rust source file starts with:
 ```toml
 version.workspace    = true
 edition.workspace    = true   # = 2021
-authors.workspace    = true   # = ["MWBMPartners"]
+authors.workspace    = true   # = ["MeedyaSuite"]
 license.workspace    = true   # = "MIT"
 repository.workspace = true
 description          = "MeedyaSuite Core — <purpose>"

--- a/.claude/PROMPTS.md
+++ b/.claude/PROMPTS.md
@@ -70,7 +70,7 @@ Add a new crate at crates/meedya-[name]/:
    - repository.workspace = true
    - description = "MeedyaSuite Core — [purpose]"
 3. Create crates/meedya-[name]/src/lib.rs with copyright header:
-   // Copyright (c) 2024-2026 MWBM Partners Ltd
+   // Copyright (c) 2026 MeedyaSuite
    // Licensed under the MIT License. See LICENSE file in the project root.
 4. Run `cargo build -p meedya-[name]` to verify wiring
 5. Update .claude/CONTEXT.md crate table

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-authors = ["MWBMPartners"]
+authors = ["MeedyaSuite"]
 license = "MIT"
 repository = "https://github.com/MWBMPartners/MeedyaSuite-core"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 MWBM Partners Ltd
+Copyright (c) 2026 MeedyaSuite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/meedya-codecs/src/audio_codec.rs
+++ b/crates/meedya-codecs/src/audio_codec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Canonical audio codec definitions.

--- a/crates/meedya-codecs/src/channel_config.rs
+++ b/crates/meedya-codecs/src/channel_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 
 use serde::{Deserialize, Serialize};

--- a/crates/meedya-codecs/src/classify.rs
+++ b/crates/meedya-codecs/src/classify.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // 4-level media classification system.

--- a/crates/meedya-codecs/src/container.rs
+++ b/crates/meedya-codecs/src/container.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Canonical container format definitions.

--- a/crates/meedya-codecs/src/error.rs
+++ b/crates/meedya-codecs/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 
 use thiserror::Error;

--- a/crates/meedya-codecs/src/ffprobe.rs
+++ b/crates/meedya-codecs/src/ffprobe.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Adapted from interesting-mirzakhani. Returns `Option<AudioCodec>` where

--- a/crates/meedya-codecs/src/hdr.rs
+++ b/crates/meedya-codecs/src/hdr.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // HDR format definitions.

--- a/crates/meedya-codecs/src/lib.rs
+++ b/crates/meedya-codecs/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // meedya-codecs — Shared codec, container, and media format definitions

--- a/crates/meedya-codecs/src/mediainfo.rs
+++ b/crates/meedya-codecs/src/mediainfo.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Adapted from interesting-mirzakhani. Uses the new `SpatialType` enum

--- a/crates/meedya-codecs/src/registry.rs
+++ b/crates/meedya-codecs/src/registry.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // TOML-driven codec registry for service-specific flag mapping.

--- a/crates/meedya-codecs/src/spatial.rs
+++ b/crates/meedya-codecs/src/spatial.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Spatial audio format definitions.

--- a/crates/meedya-codecs/src/spatial_type.rs
+++ b/crates/meedya-codecs/src/spatial_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Coarse-grained spatial audio detection categories. This is distinct from

--- a/crates/meedya-codecs/src/subtitle_codec.rs
+++ b/crates/meedya-codecs/src/subtitle_codec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Canonical subtitle/caption codec definitions.

--- a/crates/meedya-codecs/src/video_codec.rs
+++ b/crates/meedya-codecs/src/video_codec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Canonical video codec definitions.

--- a/crates/meedya-db/src/client.rs
+++ b/crates/meedya-db/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // MeedyaDB API client.

--- a/crates/meedya-db/src/error.rs
+++ b/crates/meedya-db/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 
 use thiserror::Error;

--- a/crates/meedya-db/src/export.rs
+++ b/crates/meedya-db/src/export.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Database export trait.

--- a/crates/meedya-db/src/lib.rs
+++ b/crates/meedya-db/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // meedya-db — Shared database schema, models, and MeedyaDB API client

--- a/crates/meedya-db/src/models.rs
+++ b/crates/meedya-db/src/models.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Core media record types shared across all MeedyaSuite applications.

--- a/crates/meedya-fingerprint/src/acoustid.rs
+++ b/crates/meedya-fingerprint/src/acoustid.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // AcoustID fingerprinting and lookup.

--- a/crates/meedya-fingerprint/src/error.rs
+++ b/crates/meedya-fingerprint/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 
 use thiserror::Error;

--- a/crates/meedya-fingerprint/src/lib.rs
+++ b/crates/meedya-fingerprint/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // meedya-fingerprint — AcoustID fingerprinting and ReplayGain analysis

--- a/crates/meedya-fingerprint/src/replaygain.rs
+++ b/crates/meedya-fingerprint/src/replaygain.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // ReplayGain loudness analysis via FFmpeg EBU R128.

--- a/crates/meedya-library-import/src/cuesheet.rs
+++ b/crates/meedya-library-import/src/cuesheet.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // CUE sheet parser and import adapter.

--- a/crates/meedya-library-import/src/itunes_xml.rs
+++ b/crates/meedya-library-import/src/itunes_xml.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // iTunes / Music.app XML library importer.

--- a/crates/meedya-library-import/src/lib.rs
+++ b/crates/meedya-library-import/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // meedya-library-import — Ingest soft playback bounds (and adjacent metadata)

--- a/crates/meedya-metadata/src/codec_tags.rs
+++ b/crates/meedya-metadata/src/codec_tags.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // Codec-specific metadata tags for M4A files.

--- a/crates/meedya-metadata/src/common_tags.rs
+++ b/crates/meedya-metadata/src/common_tags.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Common/standard metadata tag key definitions.

--- a/crates/meedya-metadata/src/error.rs
+++ b/crates/meedya-metadata/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 
 use thiserror::Error;

--- a/crates/meedya-metadata/src/json_path.rs
+++ b/crates/meedya-metadata/src/json_path.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // JSON path extraction and value conversion.

--- a/crates/meedya-metadata/src/lib.rs
+++ b/crates/meedya-metadata/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // meedya-metadata — Tag schemas, metadata read/write, TOML tag registry

--- a/crates/meedya-metadata/src/playback_bounds.rs
+++ b/crates/meedya-metadata/src/playback_bounds.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // Soft playback start/stop bounds — MeedyaSuite-only metadata.

--- a/crates/meedya-metadata/src/registry.rs
+++ b/crates/meedya-metadata/src/registry.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // Metadata tag registry — config-driven tag definitions from tags.toml

--- a/crates/meedya-metadata/src/tag_io.rs
+++ b/crates/meedya-metadata/src/tag_io.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // File I/O tag reading and writing via lofty.

--- a/crates/meedya-metadata/src/tag_registry.rs
+++ b/crates/meedya-metadata/src/tag_registry.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Config-driven tag registry.

--- a/crates/meedya-metadata/src/writer.rs
+++ b/crates/meedya-metadata/src/writer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // Tag writer — writes metadata tags to M4A files using the tag registry.

--- a/crates/meedya-metadata/tags.toml
+++ b/crates/meedya-metadata/tags.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026 MWBM Partners Ltd
+# Copyright (c) 2026 MeedyaSuite
 # Licensed under the MIT License. See LICENSE file in the project root.
 #
 # MeedyaSuite Metadata Tag Registry

--- a/crates/meedya-providers/src/error.rs
+++ b/crates/meedya-providers/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 
 use thiserror::Error;

--- a/crates/meedya-providers/src/lib.rs
+++ b/crates/meedya-providers/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // meedya-providers — Shared metadata provider framework

--- a/crates/meedya-providers/src/traits.rs
+++ b/crates/meedya-providers/src/traits.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Core provider traits.

--- a/crates/meedya-providers/src/types.rs
+++ b/crates/meedya-providers/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Provider-layer value types: search queries, results, cover art.

--- a/crates/meedya-tags-extended/src/io.rs
+++ b/crates/meedya-tags-extended/src/io.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // File I/O wrapper around `lofty`.

--- a/crates/meedya-tags-extended/src/lib.rs
+++ b/crates/meedya-tags-extended/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // meedya-tags-extended — Multi-format tag I/O with DJ metadata support.

--- a/crates/meedya-tags-extended/src/mik.rs
+++ b/crates/meedya-tags-extended/src/mik.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // Mixed In Key reader — recovers MIK's key / energy / tempo from every

--- a/crates/meedya-tags-extended/src/model.rs
+++ b/crates/meedya-tags-extended/src/model.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // Unified data model for extended (DJ-flavoured) tag metadata.

--- a/crates/meedya-tags-extended/src/standard.rs
+++ b/crates/meedya-tags-extended/src/standard.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2026 MWBM Partners Ltd
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License. See LICENSE file in the project root.
 //
 // Standard, non-proprietary tag read/write.


### PR DESCRIPTION
## Summary

Normalise the copyright line across MeedyaSuite-core to a single consistent form. Companion to MeedyaPlayer PR [MeedyaSuite/MeedyaPlayer#24](https://github.com/MeedyaSuite/MeedyaPlayer/pull/24), which introduces ADR 0011 (copyright held by the MeedyaSuite brand, with MWBM Partners Ltd as the legal entity behind it).

## What changed

Before this PR, copyright lines used three different forms inconsistently:

| Form | Files affected |
| --- | --- |
| `Copyright (c) 2026 MWBMPartners` | ~30 .rs files |
| `Copyright (c) 2024-2026 MWBMPartners` | a few .rs files |
| `Copyright (c) 2024-2026 MWBM Partners Ltd` | a few .rs files, `tags.toml` |
| `Copyright (c) 2026 MWBM Partners Ltd` | LICENSE |
| `authors = ["MWBMPartners"]` | `Cargo.toml` workspace |

All normalised to:

```
Copyright (c) 2026 MeedyaSuite
```

(Single year per the agreed normalisation; no "All rights reserved" because that contradicts the MIT licence grant.)

## What's *not* changed (deliberately)

URL references to `github.com/MWBMPartners/MeedyaSuite-core` are left alone — they're the actual current repo URL. The org migration (MWBMPartners → MeedyaSuite) is a separate, future change that warrants its own PR so it can be coordinated with GitHub's redirect mechanics and consumer `Cargo.toml` updates across the suite. Specifically untouched:

- `Cargo.toml` `repository` field
- `README.md` install snippets
- `crates/meedya-lyrics/src/provider/lrclib.rs` User-Agent string
- `crates/meedya-core/src/lib.rs` docstring example
- `.claude/CLAUDE.md` and `.claude/MEMORY.md` repo-pointer lines
- `docs/cross-repo-issues.md` and `docs/API.md` install snippets

One stale comment in `.claude/MEMORY.md` (showing the *previous* workspace `authors` value) was updated to reflect the new value, since it directly referenced a field this PR changes.

## Why this form

Per MeedyaPlayer's ADR 0011 (`2026-05-18`):

- **Brand** asserting copyright on MeedyaSuite-family work: **MeedyaSuite**
- **Legal entity** behind the brand (used where the entity must be named explicitly): **MWBM Partners Ltd** (UK, `MWBMpartners.ltd`)

For MIT-licensed open-source code (this crate), the conventional single-party form `Copyright (c) <year> MeedyaSuite` is used, omitting "All rights reserved" (which fits proprietary licences but contradicts MIT's grant).

## Test plan

Pure metadata / comment changes. Build & test should be unaffected.

- [ ] `cargo build --workspace` still succeeds
- [ ] `cargo test --workspace` still succeeds
- [ ] Spot-check a couple of crate headers and LICENSE for the new form
- [ ] Confirm no `MWBMPartners` *copyright* lines remain (URL references intentionally preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
