### PR TITLE
feat(meedya-fingerprint): add chromaprint feature flag + generate_fingerprint module (#10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +60,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -63,6 +75,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -222,6 +240,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -796,6 +820,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,10 +962,13 @@ dependencies = [
 name = "meedya-fingerprint"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "log",
  "reqwest",
+ "rusty-chromaprint",
  "serde",
  "serde_json",
+ "symphonia",
  "thiserror",
  "tokio",
 ]
@@ -1074,10 +1107,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1118,7 +1169,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1253,6 +1304,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -1429,7 +1489,16 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
 ]
 
 [[package]]
@@ -1438,7 +1507,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1503,10 +1572,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubato"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
 
 [[package]]
 name = "rustix"
@@ -1514,7 +1609,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1527,7 +1622,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1576,6 +1671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-chromaprint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e4234523e38d9c12201955f8216e1a60313e64c5077f4e1cf49b0db77bd7e8"
+dependencies = [
+ "rubato",
+ "rustfft",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,7 +1707,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1749,6 +1854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1886,201 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
 
 [[package]]
 name = "syn"
@@ -1813,7 +2119,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2049,7 +2355,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2102,6 +2408,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -2281,7 +2597,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2664,7 +2980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ lofty = "0.22"
 # Audio fingerprinting
 rusty-chromaprint = "0.3"
 symphonia = { version = "0.5", features = ["all"] }
+# URL-safe base64 encoding used by the Chromaprint fingerprint
+# serialiser (#10 / MeedyaDL #353 Phase 3) — Chromaprint's binary
+# fingerprint blobs are encoded to text via URL_SAFE_NO_PAD for the
+# AcoustID API.
+base64 = "0.22"
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/crates/meedya-fingerprint/Cargo.toml
+++ b/crates/meedya-fingerprint/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Meedya Core — AcoustID fingerprinting and ReplayGain loudness analysis"
+description = "Meedya Core — AcoustID fingerprinting, Chromaprint generation (opt-in), and ReplayGain loudness analysis"
 
 [dependencies]
 serde = { workspace = true }
@@ -14,3 +14,24 @@ thiserror = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 log = { workspace = true }
+
+# Optional — gated behind the `chromaprint` feature. Pulling
+# `rusty-chromaprint` + `symphonia` unconditionally would force
+# every consumer (e.g. apps that only want the AcoustID HTTP
+# client or the ReplayGain analyser) to pay the substantial
+# compile-time + binary-size cost of the audio decode stack.
+rusty-chromaprint = { workspace = true, optional = true }
+symphonia = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+
+[features]
+default = []
+# Enable the `meedya_fingerprint::chromaprint` module which produces
+# Chromaprint audio fingerprints suitable for AcoustID lookup. Pulls
+# in `rusty-chromaprint` (pure-Rust Chromaprint port) and `symphonia`
+# (pure-Rust audio decode). No external `fpcalc` binary required —
+# this is the path that enables AcoustID support on ARM Linux where
+# no fpcalc binaries exist.
+#
+# See MWBMPartners/MeedyaDL#353 Phase 3 for the consumer migration.
+chromaprint = ["dep:rusty-chromaprint", "dep:symphonia", "dep:base64"]

--- a/crates/meedya-fingerprint/src/chromaprint.rs
+++ b/crates/meedya-fingerprint/src/chromaprint.rs
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 MWBMPartners
+// Licensed under the MIT License.
+//
+// Chromaprint fingerprint generation — pure Rust, no external binaries.
+// =====================================================================
+//
+// Ported verbatim from MeedyaDL's `acoustid_service::generate_fingerprint`
+// for MeedyaDL#353 Phase 3. Lives under the `chromaprint` feature flag so
+// consumers that only want the AcoustID HTTP client or the ReplayGain
+// analyser don't pay the compile-time / binary-size cost of pulling in
+// `rusty-chromaprint` + `symphonia`.
+//
+// ## Pipeline
+//
+// 1. Open the audio file and wrap it in a Symphonia `MediaSourceStream`.
+// 2. Probe the format (M4A / FLAC / MP3 / OGG / Opus — anything Symphonia
+//    can decode). The Symphonia `Hint` carries the file extension to
+//    speed up probe.
+// 3. Locate the first audio track, instantiate a decoder for it.
+// 4. Decode every packet into interleaved `i16` PCM samples, feeding
+//    each batch into `rusty_chromaprint::Fingerprinter::consume`.
+// 5. Finalise the fingerprint, compress it with
+//    `FingerprintCompressor`, encode the compressed bytes via
+//    URL-safe base64 (no padding) — matches Chromaprint's reference
+//    `fpcalc` output format and what the AcoustID API expects.
+//
+// ## Why pure Rust matters
+//
+// The original Chromaprint reference implementation is a C binary
+// (`fpcalc`) distributed by acoustid.org. Pre-built `fpcalc` binaries
+// only exist for x86_64 macOS, x86_64 Windows, and x86_64 Linux. ARM
+// builds (Raspberry Pi 4/5, Apple Silicon servers, AWS Graviton)
+// would need users to compile fpcalc themselves. By using
+// `rusty-chromaprint` + `symphonia` we sidestep that entirely — the
+// fingerprinter compiles with the rest of the consumer app for every
+// target the consumer ships.
+//
+// ## What we don't preserve from `fpcalc`
+//
+// - **Locale-aware command-line parsing** — N/A, we're a library.
+// - **The `-stats` output flag** — debug aid, not part of the API
+//   contract.
+// - **Streaming-from-stdin mode** — we always work from a file path.
+//
+// The fingerprint format and compression algorithm are byte-for-byte
+// compatible with `fpcalc` output via `Configuration::preset_test2`
+// (Chromaprint's default algorithm). An AcoustID lookup with a
+// fingerprint produced here is indistinguishable from one produced by
+// `fpcalc -raw -plain`.
+
+use std::path::Path;
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use rusty_chromaprint::{Configuration, FingerprintCompressor, Fingerprinter};
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::{MediaSourceStream, MediaSourceStreamOptions};
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+use crate::error::FingerprintError;
+
+/// Generate a Chromaprint fingerprint for an audio file.
+///
+/// Returns `Ok((fingerprint, duration_seconds))` where:
+/// - `fingerprint` is the URL-safe-base64 encoded compressed
+///   fingerprint (no padding) — the form the AcoustID API consumes.
+/// - `duration_seconds` is the decoded duration of the audio track
+///   in whole seconds, computed from the actual sample count (NOT
+///   the container metadata, which can be wrong for re-muxed files).
+///
+/// # Errors
+///
+/// Returns a [`FingerprintError`] variant:
+/// - [`FingerprintError::IoError`] — file open failed.
+/// - [`FingerprintError::DecodeError`] — Symphonia probe or decode
+///   failure (unsupported codec, malformed file, etc.).
+/// - [`FingerprintError::FingerprintFailed`] — `rusty-chromaprint`
+///   rejected the input (too short, malformed sample stream).
+///
+/// # Blocking
+///
+/// This is a **synchronous, CPU-bound** function. Consumers in async
+/// contexts should wrap it in `tokio::task::spawn_blocking` to avoid
+/// starving the runtime — decoding a typical 4-minute song takes
+/// ~300-800ms on modern hardware.
+pub fn generate_fingerprint(file_path: &Path) -> Result<(String, u32), FingerprintError> {
+    // Open the audio file. We deliberately use `std::fs::File` here —
+    // not `tokio::fs::File` — because Symphonia's reader is a
+    // synchronous `io::Read` consumer. Async I/O would only add
+    // overhead.
+    let file = std::fs::File::open(file_path)?;
+    let mss = MediaSourceStream::new(Box::new(file), MediaSourceStreamOptions::default());
+
+    // Provide a file extension hint for format detection. Probe is
+    // robust enough to detect the format from the leading magic bytes
+    // even without the hint, but supplying it speeds the probe up.
+    let mut hint = Hint::new();
+    if let Some(ext) = file_path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+
+    // Probe the format (auto-detect M4A / MP4 / FLAC / MP3 / OGG / Opus).
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .map_err(|e| FingerprintError::DecodeError(format!("format probe: {e}")))?;
+
+    let mut format_reader = probed.format;
+
+    // Find the first audio track and capture its codec parameters.
+    let track = format_reader
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .ok_or_else(|| FingerprintError::DecodeError("no audio tracks found in file".into()))?;
+
+    let codec_params = &track.codec_params;
+    let sample_rate = codec_params
+        .sample_rate
+        .ok_or_else(|| FingerprintError::DecodeError("audio track has no sample rate".into()))?;
+    let channels = codec_params
+        .channels
+        .map(|ch| u32::try_from(ch.count()).unwrap_or(0))
+        .ok_or_else(|| FingerprintError::DecodeError("audio track has no channel info".into()))?;
+    let track_id = track.id;
+
+    // Create a decoder for the audio track.
+    let mut decoder = symphonia::default::get_codecs()
+        .make(codec_params, &DecoderOptions::default())
+        .map_err(|e| FingerprintError::DecodeError(format!("decoder init: {e}")))?;
+
+    // Initialise the Chromaprint fingerprinter with `preset_test2` —
+    // the same algorithm `fpcalc` uses by default.
+    let config = Configuration::preset_test2();
+    let mut printer = Fingerprinter::new(&config);
+    printer.start(sample_rate, channels).map_err(|e| {
+        FingerprintError::FingerprintFailed(format!("fingerprinter start: {e:?}"))
+    })?;
+
+    // Decode every packet, feed interleaved i16 samples to the
+    // fingerprinter. `total_samples` tracks the cumulative count
+    // across packets so we can compute the true duration.
+    let mut total_samples: u64 = 0;
+    let mut sample_buf: Option<SampleBuffer<i16>> = None;
+
+    loop {
+        let packet = match format_reader.next_packet() {
+            Ok(packet) => packet,
+            Err(SymphoniaError::IoError(ref e))
+                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break; // End of stream — clean termination.
+            }
+            Err(e) => {
+                return Err(FingerprintError::DecodeError(format!(
+                    "next_packet: {e}"
+                )))
+            }
+        };
+
+        // Skip packets from other tracks (unlikely for single-track
+        // M4A, but defensive against multi-track sources).
+        if packet.track_id() != track_id {
+            continue;
+        }
+
+        match decoder.decode(&packet) {
+            Ok(decoded) => {
+                // Initialise or resize the sample buffer as needed.
+                let num_frames = decoded.frames();
+                if sample_buf.is_none()
+                    || sample_buf
+                        .as_ref()
+                        .is_some_and(|b| b.capacity() < num_frames)
+                {
+                    let spec = *decoded.spec();
+                    sample_buf = Some(SampleBuffer::new(num_frames as u64, spec));
+                }
+
+                if let Some(ref mut buf) = sample_buf {
+                    buf.copy_interleaved_ref(decoded);
+                    let samples = buf.samples();
+                    total_samples += samples.len() as u64;
+                    printer.consume(samples);
+                }
+            }
+            Err(SymphoniaError::DecodeError(_)) => {
+                // Skip corrupted packets — Symphonia recovers and the
+                // next packet should be fine. A single bad packet
+                // shouldn't kill an otherwise valid fingerprint.
+            }
+            Err(e) => {
+                return Err(FingerprintError::DecodeError(format!(
+                    "decode: {e}"
+                )))
+            }
+        }
+    }
+
+    // Finalise the fingerprint.
+    printer.finish();
+    let raw_fingerprint = printer.fingerprint();
+
+    if raw_fingerprint.is_empty() {
+        return Err(FingerprintError::FingerprintFailed(
+            "generated empty fingerprint (file too short?)".into(),
+        ));
+    }
+
+    // Compress the fingerprint using Chromaprint's internal
+    // compression format, then encode in URL-safe base64 (no
+    // padding) — matches `fpcalc`'s output and what the AcoustID
+    // API consumes.
+    let compressor = FingerprintCompressor::from(&config);
+    let compressed = compressor.compress(raw_fingerprint);
+    let encoded = URL_SAFE_NO_PAD.encode(&compressed);
+
+    // Calculate duration from total decoded samples. u64::from()
+    // does the lossless widening; try_from() guards against
+    // truncation to u32 (which would only fire for tracks >
+    // ~136 years long).
+    let duration_seconds =
+        u32::try_from(total_samples / u64::from(channels) / u64::from(sample_rate))
+            .unwrap_or(u32::MAX);
+
+    Ok((encoded, duration_seconds))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_returns_io_error() {
+        let err = generate_fingerprint(Path::new("/tmp/this/path/does/not/exist.m4a"))
+            .expect_err("nonexistent path should fail");
+        // `?` on a `std::fs::File::open` failure goes through the
+        // `#[from] std::io::Error` impl on `FingerprintError::IoError`.
+        assert!(
+            matches!(err, FingerprintError::IoError(_)),
+            "expected IoError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn unrecognised_format_returns_decode_error() {
+        use std::io::Write as _;
+        // Write a file that's clearly not audio. Symphonia's probe
+        // should fail; we want to ensure that surfaces as a
+        // DecodeError rather than a panic.
+        let dir = tempfile_dir();
+        let path = dir.join("not_audio.m4a");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"this is not an audio file, it is plain text content")
+            .unwrap();
+        drop(f);
+
+        let err = generate_fingerprint(&path).expect_err("non-audio should fail");
+        assert!(
+            matches!(err, FingerprintError::DecodeError(_)),
+            "expected DecodeError, got: {err:?}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Helper: returns a process-unique temp dir created on demand.
+    /// Avoids pulling `tempfile` as a dev-dep just for this single
+    /// throwaway path.
+    fn tempfile_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "meedya-fingerprint-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn extension_hint_is_optional() {
+        // A file without an extension shouldn't crash the probe —
+        // Symphonia falls back to magic-byte detection. We can't
+        // assert success without a real audio fixture, but we CAN
+        // assert that the failure mode is a clean DecodeError and
+        // not a panic.
+        use std::io::Write as _;
+        let dir = tempfile_dir();
+        let path = dir.join("noext"); // intentionally no extension
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"garbage").unwrap();
+        drop(f);
+
+        let err = generate_fingerprint(&path).expect_err("garbage should fail cleanly");
+        assert!(matches!(err, FingerprintError::DecodeError(_)));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // ----------------------------------------------------------
+    // API surface pins
+    // ----------------------------------------------------------
+
+    #[test]
+    fn rusty_chromaprint_api_surface_unchanged() {
+        // Pins the bits of `rusty_chromaprint` this module depends on.
+        // If upstream renames `Configuration::preset_test2` or removes
+        // `FingerprintCompressor::from`, compilation here breaks first.
+        let config = Configuration::preset_test2();
+        let _printer = Fingerprinter::new(&config);
+        let _compressor = FingerprintCompressor::from(&config);
+    }
+
+    #[test]
+    fn symphonia_api_surface_unchanged() {
+        // Same pin for symphonia: probe, codecs, MediaSourceStream.
+        let _probe = symphonia::default::get_probe();
+        let _codecs = symphonia::default::get_codecs();
+        let _opts = MediaSourceStreamOptions::default();
+    }
+}

--- a/crates/meedya-fingerprint/src/lib.rs
+++ b/crates/meedya-fingerprint/src/lib.rs
@@ -5,7 +5,10 @@
 // ====================================================================
 //
 // Provides:
-// - Chromaprint audio fingerprint generation (pure Rust, no fpcalc binary)
+// - Chromaprint audio fingerprint generation (pure Rust, no fpcalc
+//   binary; opt-in via the `chromaprint` cargo feature so consumers
+//   that only want AcoustID lookup or ReplayGain analysis don't pay
+//   the compile-time cost of `rusty-chromaprint` + `symphonia`).
 // - AcoustID API lookup with rate limiting
 // - EBU R128 loudness measurement and ReplayGain calculation
 //
@@ -16,10 +19,14 @@
 // Extracted from MeedyaDL acoustid_service.rs + replaygain_service.rs.
 
 pub mod acoustid;
+#[cfg(feature = "chromaprint")]
+pub mod chromaprint;
 mod error;
 pub mod replaygain;
 
 pub use acoustid::{AcoustIdClient, AcoustIdResult};
+#[cfg(feature = "chromaprint")]
+pub use chromaprint::generate_fingerprint;
 pub use error::FingerprintError;
 pub use replaygain::{
     AlbumGainResult, ReplayGainAnalyzer, ReplayGainResult, DEFAULT_REFERENCE_LEVEL,


### PR DESCRIPTION
## Summary

Closes the implementation half of #10. Adds a new opt-in \`chromaprint\` cargo feature to \`meedya-fingerprint\` that pulls in \`rusty-chromaprint\` + \`symphonia\` + \`base64\` as optional deps and exposes \`pub fn generate_fingerprint(&Path) -> Result<(String, u32), FingerprintError>\` for consumers that need AcoustID-compatible audio fingerprints.

The implementation is a verbatim port of MeedyaDL's \`acoustid_service::generate_fingerprint\` so consumer migration is mechanical (see MeedyaDL#353 Phase 3 for the consumer-side commit).

## Commits

| Commit | Scope |
|---|---|
| \`ebf3928\` | Workspace + crate Cargo.toml: \`base64 = "0.22"\` added to \`[workspace.dependencies]\`; \`rusty-chromaprint\`, \`symphonia\`, \`base64\` added as **optional** deps on \`meedya-fingerprint\` behind a new \`chromaprint\` feature flag. Default features stay empty so consumers that only want the AcoustID HTTP client or the ReplayGain analyser pay **zero** compile-time / binary-size cost. |
| \`05f4774\` | New \`crates/meedya-fingerprint/src/chromaprint.rs\` (~280 LOC including comments). Ports MeedyaDL's \`generate_fingerprint\` verbatim — same \`preset_test2\` Chromaprint config, same Symphonia decode pipeline, same URL-safe-base64 encoding, same error-recovery on bad packets. Wires the cfg-gated module + re-export into \`lib.rs\`. 5 new unit tests pin the error paths + the rusty-chromaprint / symphonia API surface. |

## Public API (when \`chromaprint\` enabled)

\`\`\`rust
#[cfg(feature = "chromaprint")]
pub mod chromaprint;

#[cfg(feature = "chromaprint")]
pub use chromaprint::generate_fingerprint;

#[cfg(feature = "chromaprint")]
pub fn generate_fingerprint(
    file_path: &Path,
) -> Result<(String, u32), FingerprintError>;
\`\`\`

Returns \`(encoded_fingerprint, duration_seconds)\` where the fingerprint is URL-safe-base64 (no padding) — byte-for-byte compatible with \`fpcalc -raw -plain\`. Duration is computed from the actual decoded sample count, not container metadata.

## Critical property preserved

**Pure Rust, no external binaries.** \`rusty-chromaprint\` + \`symphonia\` do the entire decode pipeline. No \`fpcalc\` shell-out, no platform-specific install paths. This is what lets MeedyaDL ship AcoustID support on ARM Linux today (Pi 4/5, AWS Graviton, ARM Apple Silicon servers — no fpcalc binaries exist there), and it carries over to every future consumer of this crate.

## Test plan

- [x] \`cargo check -p meedya-fingerprint\` (default features) — clean
- [x] \`cargo check -p meedya-fingerprint --features chromaprint\` — clean
- [x] \`cargo test -p meedya-fingerprint\` (default) — 6/6 passing, zero chromaprint code compiled
- [x] \`cargo test -p meedya-fingerprint --features chromaprint\` — 11/11 passing (6 existing + 5 new)
- [x] MeedyaDL consumer-side swap landed and 1281/1281 tests pass against this branch (MeedyaDL#353 Phase 3, commit [\`19d7f2e6\`](https://github.com/MWBMPartners/MeedyaDL/commit/19d7f2e6))

## Consumer migration path

After this PR merges, MeedyaDL flips its \`Cargo.toml\` dep from \`branch = "feat/353-chromaprint-feature-flag"\` back to \`branch = "main"\` in a 1-line follow-up. Same pattern as future MeedyaSuite consumers (MeedyaConverter, MeedyaManager, iLyricsDB, iHymns) — they opt in with \`features = ["chromaprint"]\` when they need it.

## What's out of scope for this PR

- **Real-audio round-trip fingerprint test** — needs bundling a small (~50KB) audio fixture. Worth filing as a follow-up issue. End-to-end real-data coverage is currently provided by MeedyaDL running its enrichment pipeline against actual Apple Music content.
- **Public re-export through \`meedya-core\`** — consumers add \`meedya-fingerprint\` to their \`Cargo.toml\` directly today. If the umbrella re-export pattern lands later, this module rides along automatically.

Closes #10.