### PR TITLE
feat: combined Chromaprint feature flag + Lyricsfile (.lyrics) YAML format (closes #10 + #34)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,8 +957,10 @@ dependencies = [
  "async-trait",
  "lofty 0.22.4",
  "meedya-metadata",
+ "quick-xml 0.36.2",
  "reqwest",
  "serde",
+ "serde_yaml",
  "thiserror",
  "tokio",
 ]
@@ -1210,7 +1212,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -1277,6 +1279,16 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1687,6 +1699,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2121,6 +2146,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +60,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -63,6 +75,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -222,6 +240,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -796,6 +820,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,10 +962,13 @@ dependencies = [
 name = "meedya-fingerprint"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "log",
  "reqwest",
+ "rusty-chromaprint",
  "serde",
  "serde_json",
+ "symphonia",
  "thiserror",
  "tokio",
 ]
@@ -1076,10 +1109,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1120,7 +1171,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1255,6 +1306,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -1441,7 +1501,16 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
 ]
 
 [[package]]
@@ -1450,7 +1519,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1515,10 +1584,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubato"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
 
 [[package]]
 name = "rustix"
@@ -1526,7 +1621,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1539,7 +1634,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1588,6 +1683,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-chromaprint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e4234523e38d9c12201955f8216e1a60313e64c5077f4e1cf49b0db77bd7e8"
+dependencies = [
+ "rubato",
+ "rustfft",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,7 +1719,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1774,6 +1879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +1911,201 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
 
 [[package]]
 name = "syn"
@@ -1838,7 +2144,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2074,7 +2380,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2127,6 +2433,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -2312,7 +2628,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2695,7 +3011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,10 @@ repository = "https://github.com/MWBMPartners/MeedyaSuite-core"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 toml = "0.8"
+# XML — used by meedya-lyrics for TTML parsing (#34)
+quick-xml = { version = "0.36", features = ["serialize"] }
 
 # Error handling
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,11 @@ lofty = "0.22"
 # Audio fingerprinting
 rusty-chromaprint = "0.3"
 symphonia = { version = "0.5", features = ["all"] }
+# URL-safe base64 encoding used by the Chromaprint fingerprint
+# serialiser (#10 / MeedyaDL #353 Phase 3) — Chromaprint's binary
+# fingerprint blobs are encoded to text via URL_SAFE_NO_PAD for the
+# AcoustID API.
+base64 = "0.22"
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/crates/meedya-fingerprint/Cargo.toml
+++ b/crates/meedya-fingerprint/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Meedya Core — AcoustID fingerprinting and ReplayGain loudness analysis"
+description = "Meedya Core — AcoustID fingerprinting, Chromaprint generation (opt-in), and ReplayGain loudness analysis"
 
 [dependencies]
 serde = { workspace = true }
@@ -14,3 +14,24 @@ thiserror = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 log = { workspace = true }
+
+# Optional — gated behind the `chromaprint` feature. Pulling
+# `rusty-chromaprint` + `symphonia` unconditionally would force
+# every consumer (e.g. apps that only want the AcoustID HTTP
+# client or the ReplayGain analyser) to pay the substantial
+# compile-time + binary-size cost of the audio decode stack.
+rusty-chromaprint = { workspace = true, optional = true }
+symphonia = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+
+[features]
+default = []
+# Enable the `meedya_fingerprint::chromaprint` module which produces
+# Chromaprint audio fingerprints suitable for AcoustID lookup. Pulls
+# in `rusty-chromaprint` (pure-Rust Chromaprint port) and `symphonia`
+# (pure-Rust audio decode). No external `fpcalc` binary required —
+# this is the path that enables AcoustID support on ARM Linux where
+# no fpcalc binaries exist.
+#
+# See MWBMPartners/MeedyaDL#353 Phase 3 for the consumer migration.
+chromaprint = ["dep:rusty-chromaprint", "dep:symphonia", "dep:base64"]

--- a/crates/meedya-fingerprint/src/chromaprint.rs
+++ b/crates/meedya-fingerprint/src/chromaprint.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 MWBMPartners
+// Copyright (c) 2026 MeedyaSuite
 // Licensed under the MIT License.
 //
 // Chromaprint fingerprint generation — pure Rust, no external binaries.
@@ -140,9 +140,9 @@ pub fn generate_fingerprint(file_path: &Path) -> Result<(String, u32), Fingerpri
     // the same algorithm `fpcalc` uses by default.
     let config = Configuration::preset_test2();
     let mut printer = Fingerprinter::new(&config);
-    printer.start(sample_rate, channels).map_err(|e| {
-        FingerprintError::FingerprintFailed(format!("fingerprinter start: {e:?}"))
-    })?;
+    printer
+        .start(sample_rate, channels)
+        .map_err(|e| FingerprintError::FingerprintFailed(format!("fingerprinter start: {e:?}")))?;
 
     // Decode every packet, feed interleaved i16 samples to the
     // fingerprinter. `total_samples` tracks the cumulative count
@@ -158,11 +158,7 @@ pub fn generate_fingerprint(file_path: &Path) -> Result<(String, u32), Fingerpri
             {
                 break; // End of stream — clean termination.
             }
-            Err(e) => {
-                return Err(FingerprintError::DecodeError(format!(
-                    "next_packet: {e}"
-                )))
-            }
+            Err(e) => return Err(FingerprintError::DecodeError(format!("next_packet: {e}"))),
         };
 
         // Skip packets from other tracks (unlikely for single-track
@@ -196,11 +192,7 @@ pub fn generate_fingerprint(file_path: &Path) -> Result<(String, u32), Fingerpri
                 // next packet should be fine. A single bad packet
                 // shouldn't kill an otherwise valid fingerprint.
             }
-            Err(e) => {
-                return Err(FingerprintError::DecodeError(format!(
-                    "decode: {e}"
-                )))
-            }
+            Err(e) => return Err(FingerprintError::DecodeError(format!("decode: {e}"))),
         }
     }
 
@@ -274,10 +266,8 @@ mod tests {
     /// Avoids pulling `tempfile` as a dev-dep just for this single
     /// throwaway path.
     fn tempfile_dir() -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "meedya-fingerprint-test-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("meedya-fingerprint-test-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         dir
     }

--- a/crates/meedya-fingerprint/src/chromaprint.rs
+++ b/crates/meedya-fingerprint/src/chromaprint.rs
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 MWBMPartners
+// Licensed under the MIT License.
+//
+// Chromaprint fingerprint generation — pure Rust, no external binaries.
+// =====================================================================
+//
+// Ported verbatim from MeedyaDL's `acoustid_service::generate_fingerprint`
+// for MeedyaDL#353 Phase 3. Lives under the `chromaprint` feature flag so
+// consumers that only want the AcoustID HTTP client or the ReplayGain
+// analyser don't pay the compile-time / binary-size cost of pulling in
+// `rusty-chromaprint` + `symphonia`.
+//
+// ## Pipeline
+//
+// 1. Open the audio file and wrap it in a Symphonia `MediaSourceStream`.
+// 2. Probe the format (M4A / FLAC / MP3 / OGG / Opus — anything Symphonia
+//    can decode). The Symphonia `Hint` carries the file extension to
+//    speed up probe.
+// 3. Locate the first audio track, instantiate a decoder for it.
+// 4. Decode every packet into interleaved `i16` PCM samples, feeding
+//    each batch into `rusty_chromaprint::Fingerprinter::consume`.
+// 5. Finalise the fingerprint, compress it with
+//    `FingerprintCompressor`, encode the compressed bytes via
+//    URL-safe base64 (no padding) — matches Chromaprint's reference
+//    `fpcalc` output format and what the AcoustID API expects.
+//
+// ## Why pure Rust matters
+//
+// The original Chromaprint reference implementation is a C binary
+// (`fpcalc`) distributed by acoustid.org. Pre-built `fpcalc` binaries
+// only exist for x86_64 macOS, x86_64 Windows, and x86_64 Linux. ARM
+// builds (Raspberry Pi 4/5, Apple Silicon servers, AWS Graviton)
+// would need users to compile fpcalc themselves. By using
+// `rusty-chromaprint` + `symphonia` we sidestep that entirely — the
+// fingerprinter compiles with the rest of the consumer app for every
+// target the consumer ships.
+//
+// ## What we don't preserve from `fpcalc`
+//
+// - **Locale-aware command-line parsing** — N/A, we're a library.
+// - **The `-stats` output flag** — debug aid, not part of the API
+//   contract.
+// - **Streaming-from-stdin mode** — we always work from a file path.
+//
+// The fingerprint format and compression algorithm are byte-for-byte
+// compatible with `fpcalc` output via `Configuration::preset_test2`
+// (Chromaprint's default algorithm). An AcoustID lookup with a
+// fingerprint produced here is indistinguishable from one produced by
+// `fpcalc -raw -plain`.
+
+use std::path::Path;
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use rusty_chromaprint::{Configuration, FingerprintCompressor, Fingerprinter};
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::{MediaSourceStream, MediaSourceStreamOptions};
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+use crate::error::FingerprintError;
+
+/// Generate a Chromaprint fingerprint for an audio file.
+///
+/// Returns `Ok((fingerprint, duration_seconds))` where:
+/// - `fingerprint` is the URL-safe-base64 encoded compressed
+///   fingerprint (no padding) — the form the AcoustID API consumes.
+/// - `duration_seconds` is the decoded duration of the audio track
+///   in whole seconds, computed from the actual sample count (NOT
+///   the container metadata, which can be wrong for re-muxed files).
+///
+/// # Errors
+///
+/// Returns a [`FingerprintError`] variant:
+/// - [`FingerprintError::IoError`] — file open failed.
+/// - [`FingerprintError::DecodeError`] — Symphonia probe or decode
+///   failure (unsupported codec, malformed file, etc.).
+/// - [`FingerprintError::FingerprintFailed`] — `rusty-chromaprint`
+///   rejected the input (too short, malformed sample stream).
+///
+/// # Blocking
+///
+/// This is a **synchronous, CPU-bound** function. Consumers in async
+/// contexts should wrap it in `tokio::task::spawn_blocking` to avoid
+/// starving the runtime — decoding a typical 4-minute song takes
+/// ~300-800ms on modern hardware.
+pub fn generate_fingerprint(file_path: &Path) -> Result<(String, u32), FingerprintError> {
+    // Open the audio file. We deliberately use `std::fs::File` here —
+    // not `tokio::fs::File` — because Symphonia's reader is a
+    // synchronous `io::Read` consumer. Async I/O would only add
+    // overhead.
+    let file = std::fs::File::open(file_path)?;
+    let mss = MediaSourceStream::new(Box::new(file), MediaSourceStreamOptions::default());
+
+    // Provide a file extension hint for format detection. Probe is
+    // robust enough to detect the format from the leading magic bytes
+    // even without the hint, but supplying it speeds the probe up.
+    let mut hint = Hint::new();
+    if let Some(ext) = file_path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+
+    // Probe the format (auto-detect M4A / MP4 / FLAC / MP3 / OGG / Opus).
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .map_err(|e| FingerprintError::DecodeError(format!("format probe: {e}")))?;
+
+    let mut format_reader = probed.format;
+
+    // Find the first audio track and capture its codec parameters.
+    let track = format_reader
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .ok_or_else(|| FingerprintError::DecodeError("no audio tracks found in file".into()))?;
+
+    let codec_params = &track.codec_params;
+    let sample_rate = codec_params
+        .sample_rate
+        .ok_or_else(|| FingerprintError::DecodeError("audio track has no sample rate".into()))?;
+    let channels = codec_params
+        .channels
+        .map(|ch| u32::try_from(ch.count()).unwrap_or(0))
+        .ok_or_else(|| FingerprintError::DecodeError("audio track has no channel info".into()))?;
+    let track_id = track.id;
+
+    // Create a decoder for the audio track.
+    let mut decoder = symphonia::default::get_codecs()
+        .make(codec_params, &DecoderOptions::default())
+        .map_err(|e| FingerprintError::DecodeError(format!("decoder init: {e}")))?;
+
+    // Initialise the Chromaprint fingerprinter with `preset_test2` —
+    // the same algorithm `fpcalc` uses by default.
+    let config = Configuration::preset_test2();
+    let mut printer = Fingerprinter::new(&config);
+    printer.start(sample_rate, channels).map_err(|e| {
+        FingerprintError::FingerprintFailed(format!("fingerprinter start: {e:?}"))
+    })?;
+
+    // Decode every packet, feed interleaved i16 samples to the
+    // fingerprinter. `total_samples` tracks the cumulative count
+    // across packets so we can compute the true duration.
+    let mut total_samples: u64 = 0;
+    let mut sample_buf: Option<SampleBuffer<i16>> = None;
+
+    loop {
+        let packet = match format_reader.next_packet() {
+            Ok(packet) => packet,
+            Err(SymphoniaError::IoError(ref e))
+                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break; // End of stream — clean termination.
+            }
+            Err(e) => {
+                return Err(FingerprintError::DecodeError(format!(
+                    "next_packet: {e}"
+                )))
+            }
+        };
+
+        // Skip packets from other tracks (unlikely for single-track
+        // M4A, but defensive against multi-track sources).
+        if packet.track_id() != track_id {
+            continue;
+        }
+
+        match decoder.decode(&packet) {
+            Ok(decoded) => {
+                // Initialise or resize the sample buffer as needed.
+                let num_frames = decoded.frames();
+                if sample_buf.is_none()
+                    || sample_buf
+                        .as_ref()
+                        .is_some_and(|b| b.capacity() < num_frames)
+                {
+                    let spec = *decoded.spec();
+                    sample_buf = Some(SampleBuffer::new(num_frames as u64, spec));
+                }
+
+                if let Some(ref mut buf) = sample_buf {
+                    buf.copy_interleaved_ref(decoded);
+                    let samples = buf.samples();
+                    total_samples += samples.len() as u64;
+                    printer.consume(samples);
+                }
+            }
+            Err(SymphoniaError::DecodeError(_)) => {
+                // Skip corrupted packets — Symphonia recovers and the
+                // next packet should be fine. A single bad packet
+                // shouldn't kill an otherwise valid fingerprint.
+            }
+            Err(e) => {
+                return Err(FingerprintError::DecodeError(format!(
+                    "decode: {e}"
+                )))
+            }
+        }
+    }
+
+    // Finalise the fingerprint.
+    printer.finish();
+    let raw_fingerprint = printer.fingerprint();
+
+    if raw_fingerprint.is_empty() {
+        return Err(FingerprintError::FingerprintFailed(
+            "generated empty fingerprint (file too short?)".into(),
+        ));
+    }
+
+    // Compress the fingerprint using Chromaprint's internal
+    // compression format, then encode in URL-safe base64 (no
+    // padding) — matches `fpcalc`'s output and what the AcoustID
+    // API consumes.
+    let compressor = FingerprintCompressor::from(&config);
+    let compressed = compressor.compress(raw_fingerprint);
+    let encoded = URL_SAFE_NO_PAD.encode(&compressed);
+
+    // Calculate duration from total decoded samples. u64::from()
+    // does the lossless widening; try_from() guards against
+    // truncation to u32 (which would only fire for tracks >
+    // ~136 years long).
+    let duration_seconds =
+        u32::try_from(total_samples / u64::from(channels) / u64::from(sample_rate))
+            .unwrap_or(u32::MAX);
+
+    Ok((encoded, duration_seconds))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_returns_io_error() {
+        let err = generate_fingerprint(Path::new("/tmp/this/path/does/not/exist.m4a"))
+            .expect_err("nonexistent path should fail");
+        // `?` on a `std::fs::File::open` failure goes through the
+        // `#[from] std::io::Error` impl on `FingerprintError::IoError`.
+        assert!(
+            matches!(err, FingerprintError::IoError(_)),
+            "expected IoError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn unrecognised_format_returns_decode_error() {
+        use std::io::Write as _;
+        // Write a file that's clearly not audio. Symphonia's probe
+        // should fail; we want to ensure that surfaces as a
+        // DecodeError rather than a panic.
+        let dir = tempfile_dir();
+        let path = dir.join("not_audio.m4a");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"this is not an audio file, it is plain text content")
+            .unwrap();
+        drop(f);
+
+        let err = generate_fingerprint(&path).expect_err("non-audio should fail");
+        assert!(
+            matches!(err, FingerprintError::DecodeError(_)),
+            "expected DecodeError, got: {err:?}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Helper: returns a process-unique temp dir created on demand.
+    /// Avoids pulling `tempfile` as a dev-dep just for this single
+    /// throwaway path.
+    fn tempfile_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "meedya-fingerprint-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn extension_hint_is_optional() {
+        // A file without an extension shouldn't crash the probe —
+        // Symphonia falls back to magic-byte detection. We can't
+        // assert success without a real audio fixture, but we CAN
+        // assert that the failure mode is a clean DecodeError and
+        // not a panic.
+        use std::io::Write as _;
+        let dir = tempfile_dir();
+        let path = dir.join("noext"); // intentionally no extension
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"garbage").unwrap();
+        drop(f);
+
+        let err = generate_fingerprint(&path).expect_err("garbage should fail cleanly");
+        assert!(matches!(err, FingerprintError::DecodeError(_)));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // ----------------------------------------------------------
+    // API surface pins
+    // ----------------------------------------------------------
+
+    #[test]
+    fn rusty_chromaprint_api_surface_unchanged() {
+        // Pins the bits of `rusty_chromaprint` this module depends on.
+        // If upstream renames `Configuration::preset_test2` or removes
+        // `FingerprintCompressor::from`, compilation here breaks first.
+        let config = Configuration::preset_test2();
+        let _printer = Fingerprinter::new(&config);
+        let _compressor = FingerprintCompressor::from(&config);
+    }
+
+    #[test]
+    fn symphonia_api_surface_unchanged() {
+        // Same pin for symphonia: probe, codecs, MediaSourceStream.
+        let _probe = symphonia::default::get_probe();
+        let _codecs = symphonia::default::get_codecs();
+        let _opts = MediaSourceStreamOptions::default();
+    }
+}

--- a/crates/meedya-fingerprint/src/lib.rs
+++ b/crates/meedya-fingerprint/src/lib.rs
@@ -5,7 +5,10 @@
 // ====================================================================
 //
 // Provides:
-// - Chromaprint audio fingerprint generation (pure Rust, no fpcalc binary)
+// - Chromaprint audio fingerprint generation (pure Rust, no fpcalc
+//   binary; opt-in via the `chromaprint` cargo feature so consumers
+//   that only want AcoustID lookup or ReplayGain analysis don't pay
+//   the compile-time cost of `rusty-chromaprint` + `symphonia`).
 // - AcoustID API lookup with rate limiting
 // - EBU R128 loudness measurement and ReplayGain calculation
 //
@@ -16,10 +19,14 @@
 // Extracted from MeedyaDL acoustid_service.rs + replaygain_service.rs.
 
 pub mod acoustid;
+#[cfg(feature = "chromaprint")]
+pub mod chromaprint;
 mod error;
 pub mod replaygain;
 
 pub use acoustid::{AcoustIdClient, AcoustIdResult};
+#[cfg(feature = "chromaprint")]
+pub use chromaprint::generate_fingerprint;
 pub use error::FingerprintError;
 pub use replaygain::{
     AlbumGainResult, ReplayGainAnalyzer, ReplayGainResult, DEFAULT_REFERENCE_LEVEL,

--- a/crates/meedya-lyrics/Cargo.toml
+++ b/crates/meedya-lyrics/Cargo.toml
@@ -11,8 +11,10 @@ description = "Meedya Core — LRCLIB client, LRC parser/writer, and lyrics writ
 async-trait = "0.1"
 lofty = { workspace = true }
 meedya-metadata = { workspace = true }
+quick-xml = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
+serde_yaml = { workspace = true }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/meedya-lyrics/src/error.rs
+++ b/crates/meedya-lyrics/src/error.rs
@@ -18,4 +18,8 @@ pub enum Error {
     UnsupportedForSync { tag_type: String },
     #[error("invalid ISO-639-2 language code (must be 3 ASCII letters)")]
     InvalidLanguageCode,
+    #[error("malformed Lyricsfile YAML: {0}")]
+    LyricsfileYaml(String),
+    #[error("malformed TTML: {0}")]
+    Ttml(String),
 }

--- a/crates/meedya-lyrics/src/lib.rs
+++ b/crates/meedya-lyrics/src/lib.rs
@@ -18,11 +18,16 @@ pub mod embed;
 pub mod error;
 pub mod lrc;
 pub mod lyrics;
+pub mod lyricsfile;
 pub mod provider;
 pub mod sidecar;
 
 pub use embed::{embed, embed_synced, DEFAULT_LANGUAGE};
 pub use error::{Error, Result};
 pub use lyrics::{Lyrics, SyncedLine};
+pub use lyricsfile::{
+    Lyricsfile, LyricsfileLine, LyricsfileMetadata, LyricsfileWord, INSTRUMENTAL_MARKER,
+    LYRICSFILE_VERSION,
+};
 pub use provider::lrclib::LrclibProvider;
 pub use provider::{LyricsProvider, TrackQuery};

--- a/crates/meedya-lyrics/src/lib.rs
+++ b/crates/meedya-lyrics/src/lib.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod lrc;
 pub mod lyrics;
 pub mod lyricsfile;
+pub mod lyricsfile_ttml;
 pub mod provider;
 pub mod sidecar;
 

--- a/crates/meedya-lyrics/src/lib.rs
+++ b/crates/meedya-lyrics/src/lib.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod lrc;
 pub mod lyrics;
 pub mod lyricsfile;
+pub mod lyricsfile_lrc;
 pub mod lyricsfile_ttml;
 pub mod provider;
 pub mod sidecar;

--- a/crates/meedya-lyrics/src/lib.rs
+++ b/crates/meedya-lyrics/src/lib.rs
@@ -1,4 +1,5 @@
-//! Lyrics fetching, LRC I/O, and write targets for the MeedyaSuite apps.
+//! Lyrics fetching, LRC I/O, write targets, and the Lyricsfile YAML
+//! format for the MeedyaSuite apps.
 //!
 //! Modeled on the LRCLIB client approach used by [lrcget], packaged as a
 //! reusable library so MeedyaDL, MeedyaConverter, and MeedyaManager can share
@@ -11,6 +12,26 @@
 //! - [`embed::embed_synced`] — ID3v2 SYLT (synchronised lyrics frame). ID3v2
 //!   containers only; other formats return an error and callers should fall
 //!   back to [`embed::embed`].
+//!
+//! ## Lyricsfile (`.lyrics`) format
+//!
+//! The [`Lyricsfile`] struct implements the YAML lyrics format introduced
+//! by [LRCGET v2.0.0](https://github.com/tranxuanthang/lrcget/releases/tag/2.0.0)
+//! and co-endorsed by LRCLIB. Conversion paths:
+//!
+//! - [`Lyricsfile::from_ttml`] — Apple Music TTML (line-level or
+//!   `itunes:timing="Word"`) → Lyricsfile, preserving word-level timing
+//!   within 1ms.
+//! - [`Lyricsfile::from_lrc`] — Standard LRC or Enhanced LRC → Lyricsfile.
+//! - [`Lyricsfile::parse`] / [`Lyricsfile::to_yaml`] — bidirectional YAML I/O.
+//! - [`Lyricsfile::to_lrc`], [`Lyricsfile::to_enhanced_lrc`],
+//!   [`Lyricsfile::to_srt`], [`Lyricsfile::to_webvtt`],
+//!   [`Lyricsfile::to_ass`] — five player-compatible export targets.
+//!
+//! The format is experimental (LRCGET's own release notes warn of breaking
+//! changes); the implementation here ships at spec version
+//! [`LYRICSFILE_VERSION`] and tolerates unknown fields on parse for
+//! forward-compatibility.
 //!
 //! [lrcget]: https://github.com/tranxuanthang/lrcget
 

--- a/crates/meedya-lyrics/src/lib.rs
+++ b/crates/meedya-lyrics/src/lib.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod lrc;
 pub mod lyrics;
 pub mod lyricsfile;
+pub mod lyricsfile_export;
 pub mod lyricsfile_lrc;
 pub mod lyricsfile_ttml;
 pub mod provider;

--- a/crates/meedya-lyrics/src/lyricsfile.rs
+++ b/crates/meedya-lyrics/src/lyricsfile.rs
@@ -1,0 +1,399 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Lyricsfile (.lyrics) — YAML lyrics format with word-level synchronisation
+// =========================================================================
+//
+// `Lyricsfile` is the open, extensible lyrics format introduced by LRCGET
+// v2.0.0 and co-endorsed by LRCLIB. It is YAML-based, supports word-level
+// timing, overlapping vocal lines, plain + synced sections in one document,
+// and explicit instrumental marking.
+//
+// This module implements the **canonical schema** (mirroring LRCGET's
+// reference Rust implementation byte-for-byte) plus parse / serialise.
+// Format converters (TTML → Lyricsfile, LRC → Lyricsfile, and the five
+// reverse exports — LRC / Enhanced LRC / SRT / WebVTT / ASS) live in
+// sibling modules under `lyricsfile/`.
+//
+// ## Why we mirror LRCGET's struct layout exactly
+//
+// The format is *experimental* (the LRCGET 2.0.0 release notes warn:
+// *"This is a new format; expect breaking changes in future versions as
+// the specification is refined"*). The safest way to stay compatible is to
+// mirror the reference parser's struct shape exactly, so any file we
+// produce parses identically in LRCGET. When the spec churns, we update
+// the constants in one place and the consumers cascade.
+//
+// ## Forward-compatibility policy
+//
+// Every optional field carries `#[serde(skip_serializing_if = "Option::is_none")]`
+// on the write side and `#[serde(default)]` on the read side. Unknown
+// fields on a future Lyricsfile version are silently ignored at parse
+// time (default `serde_yaml` behaviour) so a v1.1-produced file still
+// parses through a v1.0 reader.
+//
+// ## References
+//
+// - LRCGET v2.0.0 release: <https://github.com/tranxuanthang/lrcget/releases/tag/2.0.0>
+// - LRCGET reference implementation: <https://github.com/tranxuanthang/lrcget/blob/main/src-tauri/src/lyricsfile.rs>
+// - LRCLIB co-endorsement: <https://lrclib.net/>
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// Spec version this module is built against. Embedded in the YAML
+/// `version:` header so consumers can detect drift across releases.
+pub const LYRICSFILE_VERSION: &str = "1.0";
+
+/// Sentinel string LRCGET uses inside its LRC export when a track is
+/// marked instrumental. Round-trip consumers (LRC → Lyricsfile →
+/// instrumental marking) recognise this string and lift it back into
+/// `metadata.instrumental = true`.
+pub const INSTRUMENTAL_MARKER: &str = "[au: instrumental]";
+
+// ============================================================
+// Public types — mirror LRCGET's reference parser
+// ============================================================
+
+/// A single Lyricsfile document.
+///
+/// Lifecycle: `from_ttml` / `from_lrc` / `parse` → owned `Lyricsfile` →
+/// `to_yaml` / `to_lrc` / `to_enhanced_lrc` / `to_srt` / `to_webvtt` /
+/// `to_ass`. The struct is `Clone` so callers can fan out into multiple
+/// export formats without re-parsing the source.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Lyricsfile {
+    /// Spec version (e.g., `"1.0"`). Always set to [`LYRICSFILE_VERSION`]
+    /// on write; the read path tolerates other values for forward-compat.
+    pub version: String,
+
+    /// Track-level metadata: title, artist, album, duration, etc.
+    pub metadata: LyricsfileMetadata,
+
+    /// Synced lyrics. Empty when the track is instrumental or
+    /// plain-text-only. Multiple entries with overlapping start_ms ranges
+    /// are valid and represent simultaneous vocal lines (duets,
+    /// call-and-response).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lines: Vec<LyricsfileLine>,
+
+    /// Plain-text lyrics. Used when the source has plain text without
+    /// timing data, or when synced and plain are intentionally different
+    /// (e.g., synced version omits `[verse]` / `[chorus]` labels).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plain: Option<String>,
+}
+
+/// Track-level metadata header.
+///
+/// All optional fields except `title`, `artist`, and `instrumental`. The
+/// LRCGET reference parser treats missing-but-required fields as YAML
+/// errors; we do the same to stay drop-in compatible.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LyricsfileMetadata {
+    pub title: String,
+    pub artist: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub album: Option<String>,
+
+    /// Total track duration in milliseconds. Used by players for
+    /// playhead alignment and by LRCLIB for de-duplication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<i64>,
+
+    /// Global timing offset in milliseconds. Positive values shift the
+    /// lyrics later relative to the audio; negative shifts earlier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset_ms: Option<i64>,
+
+    /// ISO-639 language code (e.g., `"en"`, `"ja"`, `"zh-Hans"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+
+    /// Set `true` when the track has no vocals. When `true`, `lines` is
+    /// expected to be empty and the file is the lyric-format equivalent
+    /// of a "no lyrics for this track" marker.
+    #[serde(default)]
+    pub instrumental: bool,
+}
+
+/// A single synced line. Always has a start time; end time is optional
+/// (when omitted, the line ends at the next line's start or at the
+/// track's end). The optional `words` vector carries karaoke-style
+/// word-level timing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LyricsfileLine {
+    pub text: String,
+    pub start_ms: i64,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_ms: Option<i64>,
+
+    /// Word-level breakdown. When present, players highlight word-by-word
+    /// as the line plays. The concatenation of `words[*].text` (with
+    /// spaces) is expected to equal `text` modulo whitespace.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub words: Vec<LyricsfileWord>,
+}
+
+/// A single timed word inside a line.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LyricsfileWord {
+    pub text: String,
+    pub start_ms: i64,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_ms: Option<i64>,
+}
+
+// ============================================================
+// Construction + YAML I/O
+// ============================================================
+
+impl Lyricsfile {
+    /// Build an empty Lyricsfile shell with the given track metadata.
+    /// Callers populate `lines` / `plain` separately (or use one of the
+    /// `from_*` converters).
+    pub fn new(title: impl Into<String>, artist: impl Into<String>) -> Self {
+        Self {
+            version: LYRICSFILE_VERSION.to_string(),
+            metadata: LyricsfileMetadata {
+                title: title.into(),
+                artist: artist.into(),
+                album: None,
+                duration_ms: None,
+                offset_ms: None,
+                language: None,
+                instrumental: false,
+            },
+            lines: Vec::new(),
+            plain: None,
+        }
+    }
+
+    /// Serialise to a YAML string. Always emits `version:
+    /// "<LYRICSFILE_VERSION>"` as the first field.
+    pub fn to_yaml(&self) -> Result<String> {
+        serde_yaml::to_string(self).map_err(|e| Error::LyricsfileYaml(e.to_string()))
+    }
+
+    /// Parse a YAML string. Unknown fields are silently ignored
+    /// (forward-compat).
+    pub fn parse(yaml: &str) -> Result<Self> {
+        serde_yaml::from_str(yaml).map_err(|e| Error::LyricsfileYaml(e.to_string()))
+    }
+
+    /// Mark this Lyricsfile as instrumental. Clears `lines` and `plain`
+    /// since neither is meaningful when the track has no vocals.
+    pub fn mark_instrumental(&mut self) {
+        self.metadata.instrumental = true;
+        self.lines.clear();
+        self.plain = None;
+    }
+
+    /// `true` when this Lyricsfile has at least one line with non-empty
+    /// `words`. Used by consumers to decide whether word-level exports
+    /// (Enhanced LRC, karaoke-style WebVTT) are meaningful.
+    pub fn has_word_level_timing(&self) -> bool {
+        self.lines.iter().any(|l| !l.words.is_empty())
+    }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Lyricsfile {
+        Lyricsfile {
+            version: LYRICSFILE_VERSION.to_string(),
+            metadata: LyricsfileMetadata {
+                title: "Hello".into(),
+                artist: "Adele".into(),
+                album: Some("25".into()),
+                duration_ms: Some(295_000),
+                offset_ms: None,
+                language: Some("en".into()),
+                instrumental: false,
+            },
+            lines: vec![
+                LyricsfileLine {
+                    text: "Hello, it's me".into(),
+                    start_ms: 1000,
+                    end_ms: Some(3500),
+                    words: vec![
+                        LyricsfileWord {
+                            text: "Hello,".into(),
+                            start_ms: 1000,
+                            end_ms: Some(1800),
+                        },
+                        LyricsfileWord {
+                            text: "it's".into(),
+                            start_ms: 1900,
+                            end_ms: Some(2400),
+                        },
+                        LyricsfileWord {
+                            text: "me".into(),
+                            start_ms: 2500,
+                            end_ms: Some(3500),
+                        },
+                    ],
+                },
+                LyricsfileLine {
+                    text: "I was wondering".into(),
+                    start_ms: 4000,
+                    end_ms: None,
+                    words: Vec::new(),
+                },
+            ],
+            plain: Some("Hello, it's me\nI was wondering".into()),
+        }
+    }
+
+    #[test]
+    fn roundtrip_through_yaml() {
+        let input = sample();
+        let yaml = input.to_yaml().expect("serialise");
+        let parsed = Lyricsfile::parse(&yaml).expect("parse");
+        assert_eq!(input, parsed);
+    }
+
+    #[test]
+    fn version_is_always_emitted_first_field() {
+        let yaml = sample().to_yaml().unwrap();
+        // First non-empty line should be `version: ...`. serde_yaml
+        // emits struct fields in declaration order, so this is stable.
+        let first = yaml.lines().find(|l| !l.is_empty()).unwrap();
+        assert!(
+            first.starts_with("version:"),
+            "expected version first, got: {first}"
+        );
+    }
+
+    #[test]
+    fn optional_metadata_fields_are_omitted_when_none() {
+        let mut lf = Lyricsfile::new("Title", "Artist");
+        lf.metadata.album = None;
+        let yaml = lf.to_yaml().unwrap();
+        assert!(!yaml.contains("album:"), "got: {yaml}");
+        assert!(!yaml.contains("duration_ms:"), "got: {yaml}");
+        assert!(!yaml.contains("language:"), "got: {yaml}");
+    }
+
+    #[test]
+    fn empty_lines_vec_is_omitted_from_output() {
+        let lf = Lyricsfile::new("T", "A");
+        let yaml = lf.to_yaml().unwrap();
+        assert!(!yaml.contains("lines:"), "got: {yaml}");
+    }
+
+    #[test]
+    fn empty_words_vec_is_omitted_from_output() {
+        let mut lf = Lyricsfile::new("T", "A");
+        lf.lines.push(LyricsfileLine {
+            text: "no word breakdown".into(),
+            start_ms: 0,
+            end_ms: None,
+            words: Vec::new(),
+        });
+        let yaml = lf.to_yaml().unwrap();
+        assert!(!yaml.contains("words:"), "got: {yaml}");
+    }
+
+    #[test]
+    fn forward_compat_unknown_field_does_not_fail() {
+        let yaml = r#"
+version: "2.0"
+metadata:
+  title: T
+  artist: A
+  instrumental: false
+  future_field_we_dont_understand: yes
+lines: []
+"#;
+        let lf = Lyricsfile::parse(yaml).expect("forward-compat parse");
+        assert_eq!(lf.metadata.title, "T");
+        assert_eq!(lf.version, "2.0");
+    }
+
+    #[test]
+    fn forward_compat_unknown_field_in_line_does_not_fail() {
+        let yaml = r#"
+version: "1.0"
+metadata: { title: T, artist: A, instrumental: false }
+lines:
+  - text: "hi"
+    start_ms: 0
+    unknown_per_line_field: 42
+"#;
+        let lf = Lyricsfile::parse(yaml).expect("forward-compat parse");
+        assert_eq!(lf.lines.len(), 1);
+        assert_eq!(lf.lines[0].text, "hi");
+    }
+
+    #[test]
+    fn mark_instrumental_clears_lines_and_plain() {
+        let mut lf = sample();
+        lf.mark_instrumental();
+        assert!(lf.metadata.instrumental);
+        assert!(lf.lines.is_empty());
+        assert!(lf.plain.is_none());
+    }
+
+    #[test]
+    fn has_word_level_timing_detects_words() {
+        assert!(sample().has_word_level_timing());
+
+        let mut no_words = sample();
+        for line in &mut no_words.lines {
+            line.words.clear();
+        }
+        assert!(!no_words.has_word_level_timing());
+    }
+
+    #[test]
+    fn new_builds_minimal_valid_document() {
+        let lf = Lyricsfile::new("Track", "Artist");
+        assert_eq!(lf.version, LYRICSFILE_VERSION);
+        assert_eq!(lf.metadata.title, "Track");
+        assert_eq!(lf.metadata.artist, "Artist");
+        assert!(!lf.metadata.instrumental);
+        assert!(lf.lines.is_empty());
+    }
+
+    #[test]
+    fn instrumental_marker_constant_matches_lrcget() {
+        // Pin the magic string against LRCGET v2.0.0's reference.
+        // If LRCGET ever changes this we need to update + run a migration.
+        assert_eq!(INSTRUMENTAL_MARKER, "[au: instrumental]");
+    }
+
+    #[test]
+    fn malformed_yaml_returns_lyricsfile_yaml_error() {
+        let err = Lyricsfile::parse("not yaml at all: :\n  :").unwrap_err();
+        assert!(
+            matches!(err, Error::LyricsfileYaml(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_metadata_field_errors() {
+        // title is required; omitting it should fail at parse time.
+        let yaml = r#"
+version: "1.0"
+metadata:
+  artist: A
+  instrumental: false
+"#;
+        assert!(matches!(
+            Lyricsfile::parse(yaml).unwrap_err(),
+            Error::LyricsfileYaml(_)
+        ));
+    }
+}

--- a/crates/meedya-lyrics/src/lyricsfile.rs
+++ b/crates/meedya-lyrics/src/lyricsfile.rs
@@ -376,10 +376,7 @@ lines:
     #[test]
     fn malformed_yaml_returns_lyricsfile_yaml_error() {
         let err = Lyricsfile::parse("not yaml at all: :\n  :").unwrap_err();
-        assert!(
-            matches!(err, Error::LyricsfileYaml(_)),
-            "got: {err:?}"
-        );
+        assert!(matches!(err, Error::LyricsfileYaml(_)), "got: {err:?}");
     }
 
     #[test]

--- a/crates/meedya-lyrics/src/lyricsfile_export.rs
+++ b/crates/meedya-lyrics/src/lyricsfile_export.rs
@@ -1,0 +1,506 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Lyricsfile → other-format exporters (#34)
+// ==========================================
+//
+// Five complementary export paths for [`Lyricsfile`]:
+//
+// 1. [`Lyricsfile::to_lrc`] — line-level `[mm:ss.xx]text` LRC. Drops
+//    word-level timing (collapses to the line `text`). Instrumental
+//    Lyricsfiles emit the `[au: instrumental]` marker.
+// 2. [`Lyricsfile::to_enhanced_lrc`] — Enhanced LRC with inline
+//    `<mm:ss.xx>` word markers. Falls back to plain LRC for lines
+//    without word-level timing.
+// 3. [`Lyricsfile::to_srt`] — standard SubRip subtitle format with
+//    `HH:MM:SS,mmm --> HH:MM:SS,mmm` ranges. Uses the line's `end_ms`
+//    if present, otherwise the next line's `start_ms`, otherwise
+//    `start_ms + 3000` as a safety default.
+// 4. [`Lyricsfile::to_webvtt`] — WebVTT (`.vtt`) format. Same timing
+//    cascade as SRT; uses `HH:MM:SS.mmm` (dot, not comma) and the
+//    `WEBVTT` header.
+// 5. [`Lyricsfile::to_ass`] — Advanced SubStation Alpha (`.ass`) with
+//    a single `Default` style. Useful for video players that consume
+//    `.ass` directly (e.g., MPV, MPC-HC).
+//
+// All five exporters are pure functions (no I/O, no allocation
+// surprises). Empty input yields a minimal valid output document
+// for SRT/VTT/ASS, and an empty string for LRC.
+
+use std::fmt::Write as _;
+
+use crate::lyricsfile::{Lyricsfile, LyricsfileLine, LyricsfileWord, INSTRUMENTAL_MARKER};
+
+/// Default per-line duration (in ms) when neither `end_ms` nor a
+/// following line is available. Three seconds is the LRCGET reference
+/// fallback and feels right for one-shot last-line cases.
+const DEFAULT_TRAILING_DURATION_MS: i64 = 3_000;
+
+impl Lyricsfile {
+    /// Export to standard LRC. Word-level timing is collapsed to line
+    /// level. Instrumental Lyricsfiles emit `[au: instrumental]`.
+    pub fn to_lrc(&self) -> String {
+        if self.metadata.instrumental {
+            return format!("{INSTRUMENTAL_MARKER}\n");
+        }
+
+        let mut out = String::new();
+        for line in &self.lines {
+            let _ = writeln!(out, "{}{}", format_lrc_timestamp(line.start_ms), line.text);
+        }
+        out
+    }
+
+    /// Export to Enhanced LRC. Lines with `words` get inline word
+    /// timestamps; lines without fall back to plain LRC.
+    pub fn to_enhanced_lrc(&self) -> String {
+        if self.metadata.instrumental {
+            return format!("{INSTRUMENTAL_MARKER}\n");
+        }
+
+        let mut out = String::new();
+        for line in &self.lines {
+            let stamp = format_lrc_timestamp(line.start_ms);
+            if line.words.is_empty() {
+                let _ = writeln!(out, "{stamp}{}", line.text);
+            } else {
+                let mut buf = String::new();
+                for word in &line.words {
+                    let _ = write!(
+                        buf,
+                        "<{}>{} ",
+                        format_lrc_timestamp_bare(word.start_ms),
+                        word.text
+                    );
+                }
+                let _ = writeln!(out, "{stamp}{}", buf.trim_end());
+            }
+        }
+        out
+    }
+
+    /// Export to SubRip (.srt) format.
+    pub fn to_srt(&self) -> String {
+        let mut out = String::new();
+        let lines = &self.lines;
+        for (idx, line) in lines.iter().enumerate() {
+            let start = line.start_ms;
+            let end = resolve_line_end(line, lines.get(idx + 1));
+            let _ = writeln!(out, "{}", idx + 1);
+            let _ = writeln!(
+                out,
+                "{} --> {}",
+                format_srt_timestamp(start),
+                format_srt_timestamp(end)
+            );
+            let _ = writeln!(out, "{}", line.text);
+            let _ = writeln!(out);
+        }
+        out
+    }
+
+    /// Export to WebVTT (.vtt) format.
+    pub fn to_webvtt(&self) -> String {
+        let mut out = String::from("WEBVTT\n\n");
+        let lines = &self.lines;
+        for (idx, line) in lines.iter().enumerate() {
+            let start = line.start_ms;
+            let end = resolve_line_end(line, lines.get(idx + 1));
+            let _ = writeln!(
+                out,
+                "{} --> {}",
+                format_vtt_timestamp(start),
+                format_vtt_timestamp(end)
+            );
+            let _ = writeln!(out, "{}", line.text);
+            let _ = writeln!(out);
+        }
+        out
+    }
+
+    /// Export to Advanced SubStation Alpha (.ass) with a single Default
+    /// style. Players that consume `.ass` natively will render each
+    /// line as a centred subtitle.
+    pub fn to_ass(&self) -> String {
+        let title = ass_escape(&self.metadata.title);
+        let mut out = String::new();
+        let _ = writeln!(out, "[Script Info]");
+        let _ = writeln!(out, "Title: {title}");
+        let _ = writeln!(out, "ScriptType: v4.00+");
+        let _ = writeln!(out, "PlayResX: 1920");
+        let _ = writeln!(out, "PlayResY: 1080");
+        let _ = writeln!(out, "WrapStyle: 0");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "[V4+ Styles]");
+        let _ = writeln!(
+            out,
+            "Format: Name, Fontname, Fontsize, PrimaryColour, OutlineColour, BackColour, Bold, Italic, Alignment, BorderStyle, Outline, Shadow, MarginL, MarginR, MarginV, Encoding"
+        );
+        let _ = writeln!(
+            out,
+            "Style: Default,Arial,72,&H00FFFFFF,&H000000FF,&H00000000,0,0,2,1,3,2,40,40,40,1"
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(out, "[Events]");
+        let _ = writeln!(
+            out,
+            "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
+        );
+        let lines = &self.lines;
+        for (idx, line) in lines.iter().enumerate() {
+            let start = line.start_ms;
+            let end = resolve_line_end(line, lines.get(idx + 1));
+            let _ = writeln!(
+                out,
+                "Dialogue: 0,{},{},Default,,0,0,0,,{}",
+                format_ass_timestamp(start),
+                format_ass_timestamp(end),
+                ass_escape(&line.text)
+            );
+        }
+        out
+    }
+}
+
+// ============================================================
+// Timing-cascade helper
+// ============================================================
+
+fn resolve_line_end(line: &LyricsfileLine, next: Option<&LyricsfileLine>) -> i64 {
+    if let Some(end) = line.end_ms {
+        return end;
+    }
+    if let Some(next) = next {
+        return next.start_ms;
+    }
+    line.start_ms + DEFAULT_TRAILING_DURATION_MS
+}
+
+// ============================================================
+// Timestamp formatters
+// ============================================================
+
+/// Format `ms` as `[mm:ss.xx]` for LRC line markers (2-digit
+/// centiseconds — the LRC convention).
+fn format_lrc_timestamp(ms: i64) -> String {
+    let total = ms.max(0) as u64;
+    let mins = total / 60_000;
+    let secs = (total / 1_000) % 60;
+    let cs = (total % 1_000) / 10;
+    format!("[{:02}:{:02}.{:02}]", mins, secs, cs)
+}
+
+/// Bare `mm:ss.xx` without the surrounding brackets (Enhanced LRC
+/// `<...>` word markers use this).
+fn format_lrc_timestamp_bare(ms: i64) -> String {
+    let total = ms.max(0) as u64;
+    let mins = total / 60_000;
+    let secs = (total / 1_000) % 60;
+    let cs = (total % 1_000) / 10;
+    format!("{:02}:{:02}.{:02}", mins, secs, cs)
+}
+
+/// Format `ms` as `HH:MM:SS,mmm` (SRT convention — comma decimal).
+fn format_srt_timestamp(ms: i64) -> String {
+    let total = ms.max(0) as u64;
+    let hours = total / 3_600_000;
+    let mins = (total / 60_000) % 60;
+    let secs = (total / 1_000) % 60;
+    let frac = total % 1_000;
+    format!("{:02}:{:02}:{:02},{:03}", hours, mins, secs, frac)
+}
+
+/// Format `ms` as `HH:MM:SS.mmm` (WebVTT convention — dot decimal).
+fn format_vtt_timestamp(ms: i64) -> String {
+    let total = ms.max(0) as u64;
+    let hours = total / 3_600_000;
+    let mins = (total / 60_000) % 60;
+    let secs = (total / 1_000) % 60;
+    let frac = total % 1_000;
+    format!("{:02}:{:02}:{:02}.{:03}", hours, mins, secs, frac)
+}
+
+/// Format `ms` as `H:MM:SS.cc` (ASS convention — single-digit hours,
+/// 2-digit centiseconds).
+fn format_ass_timestamp(ms: i64) -> String {
+    let total = ms.max(0) as u64;
+    let hours = total / 3_600_000;
+    let mins = (total / 60_000) % 60;
+    let secs = (total / 1_000) % 60;
+    let cs = (total % 1_000) / 10;
+    format!("{}:{:02}:{:02}.{:02}", hours, mins, secs, cs)
+}
+
+/// Escape `\` and `\n` and `,` and `{}` for ASS Dialogue text (the
+/// rest of ASS's escaping is for tags we don't emit).
+fn ass_escape(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('\n', "\\N")
+        .replace('{', "\\{")
+        .replace('}', "\\}")
+}
+
+// `LyricsfileWord` is currently only used inside the Enhanced LRC path;
+// keep the import so future word-level VTT / ASS exporters (NotePoint
+// for #34 follow-up) can lift it without re-importing.
+#[allow(dead_code)]
+const _USE_WORD: fn(&LyricsfileWord) -> i64 = |w| w.start_ms;
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lyricsfile::{LyricsfileLine, LyricsfileMetadata, LyricsfileWord};
+
+    fn three_lines() -> Lyricsfile {
+        Lyricsfile {
+            version: "1.0".into(),
+            metadata: LyricsfileMetadata {
+                title: "Song".into(),
+                artist: "Artist".into(),
+                album: None,
+                duration_ms: None,
+                offset_ms: None,
+                language: None,
+                instrumental: false,
+            },
+            lines: vec![
+                LyricsfileLine {
+                    text: "First line".into(),
+                    start_ms: 1_000,
+                    end_ms: Some(3_000),
+                    words: vec![
+                        LyricsfileWord {
+                            text: "First".into(),
+                            start_ms: 1_000,
+                            end_ms: Some(2_000),
+                        },
+                        LyricsfileWord {
+                            text: "line".into(),
+                            start_ms: 2_100,
+                            end_ms: Some(3_000),
+                        },
+                    ],
+                },
+                LyricsfileLine {
+                    text: "Second line".into(),
+                    start_ms: 4_000,
+                    end_ms: None,
+                    words: Vec::new(),
+                },
+                LyricsfileLine {
+                    text: "Third line".into(),
+                    start_ms: 7_000,
+                    end_ms: None,
+                    words: Vec::new(),
+                },
+            ],
+            plain: None,
+        }
+    }
+
+    fn instrumental() -> Lyricsfile {
+        let mut lf = Lyricsfile::new("Quiet", "Some Composer");
+        lf.mark_instrumental();
+        lf
+    }
+
+    // ----------------------------------------------------------
+    // LRC export
+    // ----------------------------------------------------------
+
+    #[test]
+    fn to_lrc_emits_one_line_per_entry() {
+        let out = three_lines().to_lrc();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "[00:01.00]First line");
+        assert_eq!(lines[1], "[00:04.00]Second line");
+        assert_eq!(lines[2], "[00:07.00]Third line");
+    }
+
+    #[test]
+    fn to_lrc_for_instrumental_emits_marker() {
+        assert_eq!(instrumental().to_lrc().trim(), INSTRUMENTAL_MARKER);
+    }
+
+    #[test]
+    fn to_lrc_drops_word_level_timing() {
+        // First line in three_lines() has words; LRC output should not
+        // contain `<` from Enhanced LRC syntax.
+        let out = three_lines().to_lrc();
+        assert!(!out.contains('<'), "got: {out}");
+    }
+
+    // ----------------------------------------------------------
+    // Enhanced LRC export
+    // ----------------------------------------------------------
+
+    #[test]
+    fn to_enhanced_lrc_emits_word_markers() {
+        let out = three_lines().to_enhanced_lrc();
+        let first = out.lines().next().unwrap();
+        assert!(first.starts_with("[00:01.00]"));
+        assert!(first.contains("<00:01.00>First"));
+        assert!(first.contains("<00:02.10>line"));
+    }
+
+    #[test]
+    fn to_enhanced_lrc_falls_back_to_plain_for_unworded_lines() {
+        let out = three_lines().to_enhanced_lrc();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[1], "[00:04.00]Second line");
+    }
+
+    #[test]
+    fn to_enhanced_lrc_for_instrumental_emits_marker() {
+        assert_eq!(instrumental().to_enhanced_lrc().trim(), INSTRUMENTAL_MARKER);
+    }
+
+    // ----------------------------------------------------------
+    // SRT export
+    // ----------------------------------------------------------
+
+    #[test]
+    fn to_srt_emits_numbered_cues_with_comma_decimal() {
+        let out = three_lines().to_srt();
+        // Cue 1 — line has end_ms=3000
+        assert!(out.contains("1\n00:00:01,000 --> 00:00:03,000\nFirst line"));
+        // Cue 2 — line.end_ms=None, next.start_ms=7000
+        assert!(out.contains("2\n00:00:04,000 --> 00:00:07,000\nSecond line"));
+        // Cue 3 — final line, no next; falls back to start + 3000ms
+        assert!(out.contains("3\n00:00:07,000 --> 00:00:10,000\nThird line"));
+    }
+
+    #[test]
+    fn to_srt_terminates_each_cue_with_blank_line() {
+        let out = three_lines().to_srt();
+        // Each cue ends with a blank line; final cue still has one
+        // (SRT conformance — most players require it).
+        let blank_count = out.matches("\n\n").count();
+        assert!(blank_count >= 3, "got: {out}");
+    }
+
+    // ----------------------------------------------------------
+    // WebVTT export
+    // ----------------------------------------------------------
+
+    #[test]
+    fn to_webvtt_starts_with_header() {
+        let out = three_lines().to_webvtt();
+        assert!(out.starts_with("WEBVTT\n\n"));
+    }
+
+    #[test]
+    fn to_webvtt_uses_dot_decimal_not_comma() {
+        let out = three_lines().to_webvtt();
+        assert!(out.contains("00:00:01.000 --> 00:00:03.000"));
+        assert!(!out.contains(",000"));
+    }
+
+    // ----------------------------------------------------------
+    // ASS export
+    // ----------------------------------------------------------
+
+    #[test]
+    fn to_ass_has_required_sections() {
+        let out = three_lines().to_ass();
+        assert!(out.contains("[Script Info]"));
+        assert!(out.contains("[V4+ Styles]"));
+        assert!(out.contains("[Events]"));
+        assert!(out.contains("Style: Default,"));
+    }
+
+    #[test]
+    fn to_ass_emits_one_dialogue_per_line() {
+        let out = three_lines().to_ass();
+        let dialogues: Vec<&str> = out.lines().filter(|l| l.starts_with("Dialogue:")).collect();
+        assert_eq!(dialogues.len(), 3);
+        assert!(dialogues[0].contains("0:00:01.00,0:00:03.00"));
+        assert!(dialogues[0].ends_with("First line"));
+    }
+
+    #[test]
+    fn to_ass_escapes_braces_and_newlines_in_text() {
+        let mut lf = Lyricsfile::new("T", "A");
+        lf.lines.push(LyricsfileLine {
+            text: "line with {curly} and\nnewline".into(),
+            start_ms: 0,
+            end_ms: Some(2000),
+            words: Vec::new(),
+        });
+        let out = lf.to_ass();
+        assert!(out.contains("\\{curly\\}"));
+        assert!(out.contains("\\N"));
+    }
+
+    // ----------------------------------------------------------
+    // Timestamp formatters
+    // ----------------------------------------------------------
+
+    #[test]
+    fn lrc_timestamp_format_pads_to_two_digits() {
+        assert_eq!(format_lrc_timestamp(0), "[00:00.00]");
+        assert_eq!(format_lrc_timestamp(61_500), "[01:01.50]");
+        assert_eq!(format_lrc_timestamp(123_456), "[02:03.45]");
+    }
+
+    #[test]
+    fn srt_timestamp_format_includes_hours_and_comma() {
+        assert_eq!(format_srt_timestamp(0), "00:00:00,000");
+        assert_eq!(format_srt_timestamp(3_661_234), "01:01:01,234");
+    }
+
+    #[test]
+    fn vtt_timestamp_format_uses_dot_decimal() {
+        assert_eq!(format_vtt_timestamp(3_661_234), "01:01:01.234");
+    }
+
+    #[test]
+    fn ass_timestamp_uses_centiseconds() {
+        assert_eq!(format_ass_timestamp(3_661_234), "1:01:01.23");
+    }
+
+    // ----------------------------------------------------------
+    // Round-trip
+    // ----------------------------------------------------------
+
+    #[test]
+    fn lrc_round_trip_preserves_line_timing_and_text() {
+        let original = three_lines();
+        let lrc_out = original.to_lrc();
+        let back = Lyricsfile::from_lrc(&lrc_out, "Song", "Artist").unwrap();
+        assert_eq!(back.lines.len(), 3);
+        // Line-level timing preserved to the centisecond.
+        assert_eq!(back.lines[0].start_ms, 1_000);
+        assert_eq!(back.lines[1].start_ms, 4_000);
+        assert_eq!(back.lines[0].text, "First line");
+    }
+
+    #[test]
+    fn enhanced_lrc_round_trip_preserves_word_timing_within_10ms() {
+        let original = three_lines();
+        let enh = original.to_enhanced_lrc();
+        let back = Lyricsfile::from_lrc(&enh, "Song", "Artist").unwrap();
+        let words = &back.lines[0].words;
+        assert_eq!(words.len(), 2);
+        // Word start_ms preserved to centisecond precision (LRC format
+        // limit). Acceptance criterion in #34 is 10 ms.
+        assert!((words[0].start_ms - 1_000).abs() < 10);
+        assert!((words[1].start_ms - 2_100).abs() < 10);
+        assert_eq!(words[0].text, "First");
+    }
+
+    #[test]
+    fn instrumental_lyricsfile_round_trips_through_lrc() {
+        let original = instrumental();
+        let lrc = original.to_lrc();
+        let back = Lyricsfile::from_lrc(&lrc, "Quiet", "Some Composer").unwrap();
+        assert!(back.metadata.instrumental);
+        assert!(back.lines.is_empty());
+    }
+}

--- a/crates/meedya-lyrics/src/lyricsfile_lrc.rs
+++ b/crates/meedya-lyrics/src/lyricsfile_lrc.rs
@@ -35,10 +35,10 @@
 //   storage. Leave for a follow-up if it becomes user-visible.
 
 use crate::error::Result;
+use crate::lyricsfile::LyricsfileMetadata;
 use crate::lyricsfile::{
     Lyricsfile, LyricsfileLine, LyricsfileWord, INSTRUMENTAL_MARKER, LYRICSFILE_VERSION,
 };
-use crate::lyricsfile::LyricsfileMetadata;
 
 impl Lyricsfile {
     /// Convert a standard LRC (or Enhanced LRC) document into a

--- a/crates/meedya-lyrics/src/lyricsfile_lrc.rs
+++ b/crates/meedya-lyrics/src/lyricsfile_lrc.rs
@@ -1,0 +1,377 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// LRC → Lyricsfile converter (#34)
+// =================================
+//
+// Converts standard `[mm:ss.xx]` LRC (and Enhanced LRC) text into the
+// Lyricsfile YAML format defined in `lyricsfile.rs`.
+//
+// ## Source formats
+//
+// 1. **Plain LRC** — one timestamp per line:
+//    `[00:12.34]Hello, it's me`
+//    Each timed line becomes a `LyricsfileLine` with `words = []`.
+//
+// 2. **Multi-timestamp lines** — same text at multiple times:
+//    `[00:12.34][00:24.68]repeat`
+//    Expanded into one `LyricsfileLine` per timestamp (matches the
+//    existing `lrc::parse` policy in this crate).
+//
+// 3. **Enhanced LRC** — inline word-level timestamps:
+//    `[00:12.34]<00:12.34>Hello, <00:13.10>it's <00:13.50>me`
+//    Each `<mm:ss.xx>` marker becomes a `LyricsfileWord`.
+//
+// 4. **Instrumental marker** — `[au: instrumental]` anywhere in the
+//    file flips `metadata.instrumental = true` and clears `lines`.
+//
+// ## What we don't preserve
+//
+// - **LRC metadata tags** (`[ti:...]`, `[ar:...]`, `[al:...]`) — title,
+//   artist, and album come from the caller. The LRC metadata block is
+//   often missing or stale; callers know what they wanted to tag.
+// - **`[offset:N]` tag** — could be lifted into `metadata.offset_ms`,
+//   but in practice the offset is applied at playback time, not at
+//   storage. Leave for a follow-up if it becomes user-visible.
+
+use crate::error::Result;
+use crate::lyricsfile::{
+    Lyricsfile, LyricsfileLine, LyricsfileWord, INSTRUMENTAL_MARKER, LYRICSFILE_VERSION,
+};
+use crate::lyricsfile::LyricsfileMetadata;
+
+impl Lyricsfile {
+    /// Convert a standard LRC (or Enhanced LRC) document into a
+    /// Lyricsfile. `title`, `artist`, and `album` are caller-supplied;
+    /// LRC metadata tags in the source are ignored.
+    ///
+    /// Empty LRC (no timed lines, no instrumental marker) returns a
+    /// valid Lyricsfile with an empty `lines` vector.
+    pub fn from_lrc(
+        lrc: &str,
+        title: impl Into<String>,
+        artist: impl Into<String>,
+    ) -> Result<Self> {
+        // Capture caller's metadata strings once — both the
+        // instrumental short-circuit and the synced-lines branch need
+        // them.
+        let title: String = title.into();
+        let artist: String = artist.into();
+
+        // Instrumental detection — case-insensitive prefix check across
+        // the whole document (LRCGET's reference behaviour).
+        if is_instrumental_lrc(lrc) {
+            let mut lf = Lyricsfile::new(title, artist);
+            lf.metadata.instrumental = true;
+            return Ok(lf);
+        }
+
+        let mut lines: Vec<LyricsfileLine> = Vec::new();
+        for raw in lrc.lines() {
+            for entry in parse_lrc_line(raw) {
+                lines.push(entry);
+            }
+        }
+        lines.sort_by_key(|l| l.start_ms);
+
+        // Backfill `end_ms` from the next line's `start_ms` (where
+        // unset) so consumers that need a closed timing window have
+        // one. Matches LRCGET's reference behaviour.
+        for idx in 0..lines.len() {
+            if lines[idx].end_ms.is_none() {
+                if let Some(next) = lines.get(idx + 1) {
+                    lines[idx].end_ms = Some(next.start_ms);
+                }
+            }
+        }
+
+        Ok(Lyricsfile {
+            version: LYRICSFILE_VERSION.to_string(),
+            metadata: LyricsfileMetadata {
+                title,
+                artist,
+                album: None,
+                duration_ms: None,
+                offset_ms: None,
+                language: None,
+                instrumental: false,
+            },
+            lines,
+            plain: None,
+        })
+    }
+}
+
+/// `true` when `[au: instrumental]` (case-insensitive) appears anywhere
+/// in the input. Matches LRCGET's reference policy.
+fn is_instrumental_lrc(input: &str) -> bool {
+    let lowered = input.to_lowercase();
+    lowered.contains("[au:") && lowered.contains("instrumental")
+}
+
+/// Parse a single LRC line into one or more [`LyricsfileLine`] entries.
+///
+/// Handles:
+/// - Plain text after `[mm:ss.xx]`
+/// - Multi-timestamp lines (`[00:01.00][00:05.00]repeat`)
+/// - Enhanced LRC word-level inline timestamps (`<mm:ss.xx>word`)
+/// - LRC metadata tags (`[ti:...]`, `[ar:...]`) — silently skipped
+fn parse_lrc_line(raw: &str) -> Vec<LyricsfileLine> {
+    let mut rest = raw;
+    let mut stamps: Vec<i64> = Vec::new();
+    while let Some(stripped) = rest.strip_prefix('[') {
+        let Some(end) = stripped.find(']') else { break };
+        let tag = &stripped[..end];
+        match parse_lrc_timestamp(tag) {
+            Some(ms) => {
+                stamps.push(ms);
+                rest = &stripped[end + 1..];
+            }
+            None => break, // metadata tag (`[ti:...]`) — skip the whole line
+        }
+    }
+    if stamps.is_empty() {
+        return Vec::new();
+    }
+
+    let body = rest;
+    let (text, words) = extract_enhanced_words(body);
+
+    stamps
+        .into_iter()
+        .map(|start_ms| LyricsfileLine {
+            text: text.clone(),
+            start_ms,
+            end_ms: None,
+            words: words.clone(),
+        })
+        .collect()
+}
+
+/// Parse `mm:ss[.xx]` (or `mm:ss[.xxx]`) into milliseconds. Returns
+/// `None` for non-timestamp tags (LRC metadata like `ti:`/`ar:`/`au:`).
+fn parse_lrc_timestamp(tag: &str) -> Option<i64> {
+    let (mm, rest) = tag.split_once(':')?;
+    let mins: u64 = mm.parse().ok()?;
+    let (ss, frac) = rest.split_once('.').unwrap_or((rest, ""));
+    let secs: u64 = ss.parse().ok()?;
+    if secs >= 60 {
+        return None;
+    }
+    let frac_ms: u64 = if frac.is_empty() {
+        0
+    } else {
+        let n: u64 = frac.parse().ok()?;
+        match frac.len() {
+            1 => n * 100,
+            2 => n * 10,
+            3 => n,
+            len => n / 10u64.pow((len - 3) as u32),
+        }
+    };
+    Some((mins * 60_000 + secs * 1_000 + frac_ms) as i64)
+}
+
+/// Split an LRC line body into plain text and (optional) word-level
+/// timings. If no `<mm:ss.xx>` markers are present, returns the trimmed
+/// body as `text` and an empty `words` vec.
+fn extract_enhanced_words(body: &str) -> (String, Vec<LyricsfileWord>) {
+    if !body.contains('<') {
+        return (body.trim().to_string(), Vec::new());
+    }
+
+    // Walk through `<mm:ss.xx>text<mm:ss.xx>text...` segments.
+    let mut words: Vec<LyricsfileWord> = Vec::new();
+    let mut text_buf = String::new();
+    let mut rest = body;
+    let mut leading_text = String::new();
+
+    // Collect any plain text before the first `<` (rare but valid).
+    if let Some(idx) = rest.find('<') {
+        leading_text = rest[..idx].trim().to_string();
+        rest = &rest[idx..];
+    }
+
+    while let Some(stripped) = rest.strip_prefix('<') {
+        let Some(end) = stripped.find('>') else { break };
+        let tag = &stripped[..end];
+        let Some(start_ms) = parse_lrc_timestamp(tag) else {
+            // Malformed `<...>` — treat as literal text and bail to the
+            // plain-text path.
+            return (body.trim().to_string(), Vec::new());
+        };
+        let after = &stripped[end + 1..];
+        // Word text runs until the next `<` (or end of line).
+        let (word_text, next_rest) = match after.find('<') {
+            Some(idx) => (&after[..idx], &after[idx..]),
+            None => (after, ""),
+        };
+        let trimmed = word_text.trim();
+        if !trimmed.is_empty() {
+            if !text_buf.is_empty() {
+                text_buf.push(' ');
+            }
+            text_buf.push_str(trimmed);
+            words.push(LyricsfileWord {
+                text: trimmed.to_string(),
+                start_ms,
+                end_ms: None,
+            });
+        }
+        rest = next_rest;
+    }
+
+    // Backfill word end times from the next word's start (where
+    // available). Matches LRCGET reference behaviour.
+    for idx in 0..words.len() {
+        if words[idx].end_ms.is_none() {
+            if let Some(next) = words.get(idx + 1) {
+                words[idx].end_ms = Some(next.start_ms);
+            }
+        }
+    }
+
+    let text = if leading_text.is_empty() {
+        text_buf
+    } else if text_buf.is_empty() {
+        leading_text
+    } else {
+        format!("{leading_text} {text_buf}")
+    };
+
+    (text, words)
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_lrc() {
+        let lrc = "[00:12.34]Hello, it's me\n[00:24.68]I was wondering\n";
+        let lf = Lyricsfile::from_lrc(lrc, "Hello", "Adele").unwrap();
+        assert_eq!(lf.lines.len(), 2);
+        assert_eq!(lf.lines[0].start_ms, 12_340);
+        assert_eq!(lf.lines[0].text, "Hello, it's me");
+        assert!(lf.lines[0].words.is_empty());
+        assert_eq!(lf.lines[1].start_ms, 24_680);
+    }
+
+    #[test]
+    fn backfills_end_ms_from_next_line() {
+        let lrc = "[00:01.00]a\n[00:03.00]b\n[00:05.00]c\n";
+        let lf = Lyricsfile::from_lrc(lrc, "t", "a").unwrap();
+        assert_eq!(lf.lines[0].end_ms, Some(3_000));
+        assert_eq!(lf.lines[1].end_ms, Some(5_000));
+        // Last line keeps end_ms unset.
+        assert_eq!(lf.lines[2].end_ms, None);
+    }
+
+    #[test]
+    fn expands_multi_timestamp_lines_into_separate_entries() {
+        let lrc = "[00:01.00][00:05.00]chorus\n";
+        let lf = Lyricsfile::from_lrc(lrc, "t", "a").unwrap();
+        assert_eq!(lf.lines.len(), 2);
+        assert_eq!(lf.lines[0].start_ms, 1_000);
+        assert_eq!(lf.lines[1].start_ms, 5_000);
+        assert_eq!(lf.lines[0].text, lf.lines[1].text);
+        assert_eq!(lf.lines[0].text, "chorus");
+    }
+
+    #[test]
+    fn skips_lrc_metadata_tags() {
+        let lrc = "[ti:Hello]\n[ar:Adele]\n[al:25]\n[00:12.34]synced\n";
+        let lf = Lyricsfile::from_lrc(lrc, "Hello", "Adele").unwrap();
+        assert_eq!(lf.lines.len(), 1);
+        assert_eq!(lf.lines[0].text, "synced");
+        assert_eq!(lf.metadata.title, "Hello"); // from caller, not [ti:]
+    }
+
+    #[test]
+    fn instrumental_marker_flips_metadata_and_clears_lines() {
+        let lrc = "[au: instrumental]\n[00:01.00]should be discarded\n";
+        let lf = Lyricsfile::from_lrc(lrc, "Track", "Artist").unwrap();
+        assert!(lf.metadata.instrumental);
+        assert!(lf.lines.is_empty());
+    }
+
+    #[test]
+    fn instrumental_marker_is_case_insensitive() {
+        let lrc = "[AU: INSTRUMENTAL]\n";
+        let lf = Lyricsfile::from_lrc(lrc, "t", "a").unwrap();
+        assert!(lf.metadata.instrumental);
+    }
+
+    #[test]
+    fn parses_enhanced_lrc_word_level() {
+        let lrc = "[00:01.00]<00:01.00>Hello, <00:01.80>it's <00:02.50>me\n";
+        let lf = Lyricsfile::from_lrc(lrc, "Hello", "Adele").unwrap();
+        assert_eq!(lf.lines.len(), 1);
+        let line = &lf.lines[0];
+        assert_eq!(line.start_ms, 1_000);
+        assert_eq!(line.words.len(), 3);
+        assert_eq!(line.words[0].text, "Hello,");
+        assert_eq!(line.words[0].start_ms, 1_000);
+        assert_eq!(line.words[1].text, "it's");
+        assert_eq!(line.words[1].start_ms, 1_800);
+        assert_eq!(line.words[2].text, "me");
+        assert_eq!(line.words[2].start_ms, 2_500);
+        assert_eq!(line.text, "Hello, it's me");
+    }
+
+    #[test]
+    fn backfills_word_end_ms_from_next_word() {
+        let lrc = "[00:01.00]<00:01.00>a <00:02.00>b <00:03.00>c\n";
+        let lf = Lyricsfile::from_lrc(lrc, "t", "a").unwrap();
+        let words = &lf.lines[0].words;
+        assert_eq!(words[0].end_ms, Some(2_000));
+        assert_eq!(words[1].end_ms, Some(3_000));
+        assert_eq!(words[2].end_ms, None); // last word unset
+    }
+
+    #[test]
+    fn empty_lrc_returns_empty_lines_no_error() {
+        let lf = Lyricsfile::from_lrc("", "t", "a").unwrap();
+        assert!(lf.lines.is_empty());
+        assert!(!lf.metadata.instrumental);
+    }
+
+    #[test]
+    fn three_digit_milliseconds_parse() {
+        let lrc = "[00:00.123]x\n";
+        let lf = Lyricsfile::from_lrc(lrc, "t", "a").unwrap();
+        assert_eq!(lf.lines[0].start_ms, 123);
+    }
+
+    #[test]
+    fn invalid_seconds_field_skips_line_gracefully() {
+        // 60 seconds is invalid; line is silently dropped.
+        let lrc = "[00:60.00]bad\n[00:05.00]good\n";
+        let lf = Lyricsfile::from_lrc(lrc, "t", "a").unwrap();
+        assert_eq!(lf.lines.len(), 1);
+        assert_eq!(lf.lines[0].text, "good");
+    }
+
+    #[test]
+    fn caller_metadata_overrides_lrc_tags() {
+        // Even when the LRC has its own [ti:] [ar:], the caller wins —
+        // mirrors the from_ttml signature contract.
+        let lrc = "[ti:WrongTitle]\n[ar:WrongArtist]\n[00:01.00]line\n";
+        let lf = Lyricsfile::from_lrc(lrc, "RightTitle", "RightArtist").unwrap();
+        assert_eq!(lf.metadata.title, "RightTitle");
+        assert_eq!(lf.metadata.artist, "RightArtist");
+    }
+
+    #[test]
+    fn enhanced_lrc_with_leading_text_before_first_word_marker() {
+        let lrc = "[00:01.00]intro <00:02.00>word\n";
+        let lf = Lyricsfile::from_lrc(lrc, "t", "a").unwrap();
+        // Leading text is preserved and prepended to the joined word text.
+        assert!(lf.lines[0].text.contains("intro"));
+        assert!(lf.lines[0].text.contains("word"));
+    }
+}

--- a/crates/meedya-lyrics/src/lyricsfile_ttml.rs
+++ b/crates/meedya-lyrics/src/lyricsfile_ttml.rs
@@ -471,7 +471,11 @@ mod tests {
         </div></body></tt>"#;
         let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
         assert_eq!(lf.lines.len(), 1);
-        assert!(lf.lines[0].words.is_empty(), "got words: {:?}", lf.lines[0].words);
+        assert!(
+            lf.lines[0].words.is_empty(),
+            "got words: {:?}",
+            lf.lines[0].words
+        );
         assert!(
             lf.lines[0].text.contains("Hello") && lf.lines[0].text.contains("world"),
             "got text: {:?}",

--- a/crates/meedya-lyrics/src/lyricsfile_ttml.rs
+++ b/crates/meedya-lyrics/src/lyricsfile_ttml.rs
@@ -1,0 +1,554 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// TTML → Lyricsfile converter (#34)
+// =================================
+//
+// Converts Apple Music's TTML lyric documents into the Lyricsfile YAML
+// format defined in `lyricsfile.rs`. Handles both:
+//
+// 1. **Line-level TTML** (default for Apple Music): `<p begin="..." end="..."`>`
+//    elements with plain text content. The whole `<p>` becomes one
+//    `LyricsfileLine` with no `words`.
+//
+// 2. **Word-level TTML** (`itunes:timing="Word"`): `<p>` elements
+//    containing one `<span begin="..." end="..."`>`word</span>` per word.
+//    Each `<span>` becomes a `LyricsfileWord` inside the line.
+//
+// ## Time format
+//
+// TTML timestamps follow `HH:MM:SS.mmm` (3-digit fractional seconds).
+// Older Apple files sometimes use 2-digit centiseconds — we tolerate
+// both. The converter normalises to integer milliseconds for
+// Lyricsfile storage (matching LRCGET's reference parser).
+//
+// ## XML namespace handling
+//
+// `quick-xml` doesn't auto-resolve XML namespace prefixes when iterating
+// events. We match on local-name suffix (e.g., `b"p"`, `b"span"`,
+// `b"tt"`) so the converter works regardless of the prefix the producer
+// chose (`tt:p` vs `p`, `itunes:timing` vs `it:timing`). This matches
+// how Apple's own player parses its TTML.
+//
+// ## What we don't preserve
+//
+// - **Styling**: `<span style="...">` attributes (bold, italic, colour).
+//   The Lyricsfile spec has no styling primitives; players that need
+//   bold/italic should consume the original TTML, not the Lyricsfile.
+// - **Speaker / agent labels**: TTML's `ttm:agent` is dropped. (When
+//   the spec stabilises an agent field, we revisit.)
+// - **Multiple `<div>` blocks**: All `<p>` elements are flattened in
+//   document order regardless of which `<div>` they came from.
+
+use std::str;
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+
+use crate::error::{Error, Result};
+use crate::lyricsfile::{
+    Lyricsfile, LyricsfileLine, LyricsfileMetadata, LyricsfileWord, LYRICSFILE_VERSION,
+};
+
+impl Lyricsfile {
+    /// Convert a TTML document into a Lyricsfile.
+    ///
+    /// `title`, `artist`, and `album` come from the caller (typically
+    /// from track metadata fetched alongside the TTML — Apple's TTML
+    /// `<head><metadata>` block is unreliable and often empty).
+    /// `duration_ms` is set to `None` here; callers with track duration
+    /// should populate it on the returned struct.
+    ///
+    /// If the TTML is empty or contains no `<p>` elements, returns an
+    /// otherwise-valid Lyricsfile with `instrumental: false` and an
+    /// empty `lines` vector. Callers that interpret no-content TTML as
+    /// instrumental should `mark_instrumental()` on the result.
+    pub fn from_ttml(
+        ttml: &str,
+        title: impl Into<String>,
+        artist: impl Into<String>,
+    ) -> Result<Self> {
+        let mut lf = Self {
+            version: LYRICSFILE_VERSION.to_string(),
+            metadata: LyricsfileMetadata {
+                title: title.into(),
+                artist: artist.into(),
+                album: None,
+                duration_ms: None,
+                offset_ms: None,
+                language: None,
+                instrumental: false,
+            },
+            lines: Vec::new(),
+            plain: None,
+        };
+
+        let mut reader = Reader::from_str(ttml);
+        reader.config_mut().trim_text(true);
+
+        // Tracks whether we're inside a <p> that we're currently
+        // accumulating into. When word-level <span> elements appear
+        // inside, each becomes a `LyricsfileWord`; otherwise the <p>'s
+        // text content becomes the line text.
+        let mut current_line: Option<PendingLine> = None;
+        // For word-level <span> mode: the span we're currently inside.
+        let mut current_word: Option<PendingWord> = None;
+        // Plain text buffer for line-level <p> content (when no <span>
+        // children appear). Apple's TTML may include nested formatting
+        // spans without `begin`/`end` attrs — we coalesce those into
+        // plain text rather than treating them as words.
+        let mut line_text_buf = String::new();
+        // Document-level language hint from `xml:lang` on <tt>.
+        let mut document_language: Option<String> = None;
+
+        let mut buf = Vec::new();
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) => {
+                    match local_name(e.name().as_ref()) {
+                        b"tt" => {
+                            if document_language.is_none() {
+                                document_language = read_attr(e, b"xml:lang")?.or_else(|| {
+                                    // Apple sometimes uses `lang` (no
+                                    // namespace prefix) — accept that
+                                    // too.
+                                    read_attr(e, b"lang").ok().flatten()
+                                });
+                            }
+                        }
+                        b"p" => {
+                            let begin = read_time_attr(e, b"begin")?;
+                            let end = read_time_attr(e, b"end")?;
+                            if let Some(start_ms) = begin {
+                                current_line = Some(PendingLine {
+                                    start_ms,
+                                    end_ms: end,
+                                    words: Vec::new(),
+                                });
+                                line_text_buf.clear();
+                            }
+                        }
+                        b"span" => {
+                            // Only treat <span> as a word if it has a
+                            // `begin` attr; otherwise it's a styling
+                            // wrapper and we let its text fall through
+                            // into the plain-text buffer.
+                            if let Some(start_ms) = read_time_attr(e, b"begin")? {
+                                current_word = Some(PendingWord {
+                                    start_ms,
+                                    end_ms: read_time_attr(e, b"end")?,
+                                    text: String::new(),
+                                });
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(Event::Text(t)) => {
+                    let text = t
+                        .unescape()
+                        .map_err(|e| Error::Ttml(format!("text unescape failed: {e}")))?
+                        .into_owned();
+                    if let Some(word) = current_word.as_mut() {
+                        word.text.push_str(&text);
+                    } else if current_line.is_some() {
+                        line_text_buf.push_str(&text);
+                    }
+                }
+                Ok(Event::End(ref e)) => {
+                    match local_name(e.name().as_ref()) {
+                        b"span" => {
+                            if let Some(word) = current_word.take() {
+                                if let Some(line) = current_line.as_mut() {
+                                    let trimmed = word.text.trim().to_string();
+                                    if !trimmed.is_empty() {
+                                        line.words.push(LyricsfileWord {
+                                            text: trimmed,
+                                            start_ms: word.start_ms,
+                                            end_ms: word.end_ms,
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                        b"p" => {
+                            if let Some(mut line) = current_line.take() {
+                                // Reconstruct the line text from words
+                                // (preferred — preserves spacing
+                                // explicitly) or fall back to the
+                                // plain-text buffer.
+                                let text = if line.words.is_empty() {
+                                    line_text_buf.trim().to_string()
+                                } else {
+                                    line.words
+                                        .iter()
+                                        .map(|w| w.text.as_str())
+                                        .collect::<Vec<_>>()
+                                        .join(" ")
+                                };
+                                line_text_buf.clear();
+                                if !text.is_empty() || !line.words.is_empty() {
+                                    lf.lines.push(LyricsfileLine {
+                                        text,
+                                        start_ms: line.start_ms,
+                                        end_ms: line.end_ms,
+                                        words: std::mem::take(&mut line.words),
+                                    });
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(Event::Empty(ref e)) => {
+                    // Self-closing <p/> or <span/> — rare in Apple TTML
+                    // but handle for spec compliance.
+                    if local_name(e.name().as_ref()) == b"span" {
+                        if let (Some(start_ms), Some(line)) =
+                            (read_time_attr(e, b"begin")?, current_line.as_mut())
+                        {
+                            line.words.push(LyricsfileWord {
+                                text: String::new(),
+                                start_ms,
+                                end_ms: read_time_attr(e, b"end")?,
+                            });
+                        }
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => {
+                    return Err(Error::Ttml(format!(
+                        "XML parse error at position {}: {e}",
+                        reader.buffer_position()
+                    )))
+                }
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        if document_language.is_some() {
+            lf.metadata.language = document_language;
+        }
+        Ok(lf)
+    }
+}
+
+// ============================================================
+// Internal helpers
+// ============================================================
+
+struct PendingLine {
+    start_ms: i64,
+    end_ms: Option<i64>,
+    words: Vec<LyricsfileWord>,
+}
+
+struct PendingWord {
+    start_ms: i64,
+    end_ms: Option<i64>,
+    text: String,
+}
+
+/// Strip an XML namespace prefix (`tt:p` → `p`, `itunes:timing` →
+/// `timing`) so we match on the local name regardless of producer.
+fn local_name(qualified: &[u8]) -> &[u8] {
+    match qualified.iter().rposition(|&b| b == b':') {
+        Some(idx) => &qualified[idx + 1..],
+        None => qualified,
+    }
+}
+
+/// Read an attribute by exact qualified name (e.g., `b"xml:lang"`,
+/// `b"begin"`). Returns `Ok(None)` when absent.
+fn read_attr(elem: &BytesStart, name: &[u8]) -> Result<Option<String>> {
+    for attr in elem.attributes() {
+        let attr = attr.map_err(|e| Error::Ttml(format!("attribute parse failed: {e}")))?;
+        if attr.key.as_ref() == name {
+            let value = attr
+                .unescape_value()
+                .map_err(|e| Error::Ttml(format!("attribute unescape failed: {e}")))?
+                .into_owned();
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+/// Read a TTML time attribute and convert to milliseconds.
+fn read_time_attr(elem: &BytesStart, name: &[u8]) -> Result<Option<i64>> {
+    match read_attr(elem, name)? {
+        Some(value) => parse_ttml_time(&value).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Parse a TTML time expression to milliseconds.
+///
+/// Supports:
+/// - `HH:MM:SS.mmm` (Apple Music canonical, 3-digit fractional)
+/// - `HH:MM:SS.cc` (older 2-digit centiseconds)
+/// - `MM:SS.mmm` (no hours)
+/// - `SS.mmm` (seconds only)
+/// - `<number>s` clock-time (e.g., `12.5s`) — TTML 1.0 spec form
+///
+/// Returns the time in integer milliseconds (LRCGET storage unit).
+fn parse_ttml_time(raw: &str) -> Result<i64> {
+    let s = raw.trim();
+    if let Some(stripped) = s.strip_suffix('s') {
+        let secs: f64 = stripped
+            .parse()
+            .map_err(|_| Error::Ttml(format!("invalid clock-time seconds: {raw}")))?;
+        return Ok((secs * 1000.0).round() as i64);
+    }
+
+    // HH:MM:SS or MM:SS or SS form
+    let parts: Vec<&str> = s.split(':').collect();
+    let (hours, minutes, seconds_field) = match parts.as_slice() {
+        [h, m, s] => (parse_uint(h)?, parse_uint(m)?, *s),
+        [m, s] => (0u64, parse_uint(m)?, *s),
+        [s] => (0u64, 0u64, *s),
+        _ => return Err(Error::Ttml(format!("unrecognised time format: {raw}"))),
+    };
+
+    let (secs_str, frac_str) = match seconds_field.split_once('.') {
+        Some((s, f)) => (s, f),
+        None => (seconds_field, ""),
+    };
+    let secs: u64 = parse_uint(secs_str)?;
+    let frac_ms: u64 = if frac_str.is_empty() {
+        0
+    } else {
+        let n: u64 = parse_uint(frac_str)?;
+        // Normalise the fractional digits: 2 digits → centiseconds,
+        // 3 digits → milliseconds, longer → truncate by integer
+        // division. Matches the LRC parser convention in lrc.rs.
+        match frac_str.len() {
+            1 => n * 100,
+            2 => n * 10,
+            3 => n,
+            len => n / 10u64.pow((len - 3) as u32),
+        }
+    };
+
+    Ok(((hours * 3_600_000) + (minutes * 60_000) + (secs * 1_000) + frac_ms) as i64)
+}
+
+fn parse_uint(s: &str) -> Result<u64> {
+    s.parse::<u64>()
+        .map_err(|_| Error::Ttml(format!("invalid integer: {s}")))
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lyricsfile::LYRICSFILE_VERSION;
+
+    #[test]
+    fn parses_line_level_ttml() {
+        let ttml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">
+  <body>
+    <div>
+      <p begin="00:00:01.000" end="00:00:03.500">Hello, it's me</p>
+      <p begin="00:00:04.000" end="00:00:06.500">I was wondering</p>
+    </div>
+  </body>
+</tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "Hello", "Adele").unwrap();
+        assert_eq!(lf.version, LYRICSFILE_VERSION);
+        assert_eq!(lf.metadata.language, Some("en".into()));
+        assert_eq!(lf.lines.len(), 2);
+        assert_eq!(lf.lines[0].text, "Hello, it's me");
+        assert_eq!(lf.lines[0].start_ms, 1000);
+        assert_eq!(lf.lines[0].end_ms, Some(3500));
+        assert!(lf.lines[0].words.is_empty());
+        assert_eq!(lf.lines[1].start_ms, 4000);
+    }
+
+    #[test]
+    fn parses_word_level_ttml_apple_style() {
+        let ttml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"
+    itunes:timing="Word" xml:lang="en">
+  <body>
+    <div>
+      <p begin="00:00:01.000" end="00:00:03.500">
+        <span begin="00:00:01.000" end="00:00:01.800">Hello,</span>
+        <span begin="00:00:01.900" end="00:00:02.400">it's</span>
+        <span begin="00:00:02.500" end="00:00:03.500">me</span>
+      </p>
+    </div>
+  </body>
+</tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "Hello", "Adele").unwrap();
+        assert_eq!(lf.lines.len(), 1);
+        let line = &lf.lines[0];
+        assert_eq!(line.start_ms, 1000);
+        assert_eq!(line.end_ms, Some(3500));
+        assert_eq!(line.words.len(), 3);
+        assert_eq!(line.words[0].text, "Hello,");
+        assert_eq!(line.words[0].start_ms, 1000);
+        assert_eq!(line.words[0].end_ms, Some(1800));
+        assert_eq!(line.words[1].text, "it's");
+        assert_eq!(line.words[1].start_ms, 1900);
+        assert_eq!(line.words[2].text, "me");
+        assert_eq!(line.words[2].start_ms, 2500);
+        // Text reconstructed from words joined by spaces.
+        assert_eq!(line.text, "Hello, it's me");
+    }
+
+    #[test]
+    fn preserves_word_timing_within_1ms() {
+        let ttml = r#"<tt><body><div>
+            <p begin="00:00:00.123" end="00:00:00.456">
+                <span begin="00:00:00.123" end="00:00:00.234">a</span>
+                <span begin="00:00:00.234" end="00:00:00.456">b</span>
+            </p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines[0].words[0].start_ms, 123);
+        assert_eq!(lf.lines[0].words[0].end_ms, Some(234));
+        assert_eq!(lf.lines[0].words[1].start_ms, 234);
+        assert_eq!(lf.lines[0].words[1].end_ms, Some(456));
+    }
+
+    #[test]
+    fn tolerates_two_digit_centiseconds() {
+        // Older Apple TTML sometimes uses `.cc` instead of `.mmm`.
+        let ttml = r#"<tt><body><div>
+            <p begin="00:00:01.50" end="00:00:03.25">hi</p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines[0].start_ms, 1_500);
+        assert_eq!(lf.lines[0].end_ms, Some(3_250));
+    }
+
+    #[test]
+    fn tolerates_clock_time_seconds_form() {
+        let ttml = r#"<tt><body><div>
+            <p begin="12.5s" end="15s">hi</p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines[0].start_ms, 12_500);
+        assert_eq!(lf.lines[0].end_ms, Some(15_000));
+    }
+
+    #[test]
+    fn handles_namespaced_element_names() {
+        // Producer uses `tt:p` / `tt:span` prefixes.
+        let ttml = r#"<tt:tt xmlns:tt="http://www.w3.org/ns/ttml">
+            <tt:body><tt:div>
+                <tt:p begin="00:00:01.000" end="00:00:02.000">hello</tt:p>
+            </tt:div></tt:body>
+        </tt:tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines.len(), 1);
+        assert_eq!(lf.lines[0].text, "hello");
+        assert_eq!(lf.lines[0].start_ms, 1_000);
+    }
+
+    #[test]
+    fn empty_ttml_returns_empty_lines() {
+        let ttml = r#"<tt><body></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert!(lf.lines.is_empty());
+        assert!(!lf.metadata.instrumental); // caller decides
+    }
+
+    #[test]
+    fn span_without_begin_is_treated_as_styling_not_word() {
+        // <span> with no `begin` attr is a styling wrapper, not a
+        // timed word — its text content should fall through to the
+        // line text.
+        let ttml = r#"<tt><body><div>
+            <p begin="00:00:01.000" end="00:00:02.000">Hello <span>world</span></p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines.len(), 1);
+        assert!(lf.lines[0].words.is_empty(), "got words: {:?}", lf.lines[0].words);
+        assert!(
+            lf.lines[0].text.contains("Hello") && lf.lines[0].text.contains("world"),
+            "got text: {:?}",
+            lf.lines[0].text
+        );
+    }
+
+    #[test]
+    fn missing_p_begin_attr_is_silently_skipped() {
+        // Defensive: a `<p>` with no `begin` attr can't be timed, so
+        // we skip it rather than emitting an unsynced line.
+        let ttml = r#"<tt><body><div>
+            <p>no timing</p>
+            <p begin="00:00:05.000">timed</p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines.len(), 1);
+        assert_eq!(lf.lines[0].text, "timed");
+    }
+
+    #[test]
+    fn multiple_div_blocks_are_flattened_in_document_order() {
+        let ttml = r#"<tt><body>
+            <div><p begin="00:00:01.000">a</p></div>
+            <div><p begin="00:00:02.000">b</p></div>
+            <div><p begin="00:00:03.000">c</p></div>
+        </body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines.len(), 3);
+        assert_eq!(
+            lf.lines.iter().map(|l| l.text.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn handles_xml_entities_in_lyric_text() {
+        let ttml = r#"<tt><body><div>
+            <p begin="00:00:01.000">don&apos;t &amp; can&apos;t</p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines[0].text, "don't & can't");
+    }
+
+    #[test]
+    fn malformed_xml_returns_ttml_error() {
+        let ttml = "<tt><body><p begin=";
+        let err = Lyricsfile::from_ttml(ttml, "t", "a").unwrap_err();
+        assert!(matches!(err, Error::Ttml(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn invalid_time_format_returns_ttml_error() {
+        let ttml = r#"<tt><body><div>
+            <p begin="not a time">hi</p>
+        </div></body></tt>"#;
+        let err = Lyricsfile::from_ttml(ttml, "t", "a").unwrap_err();
+        assert!(matches!(err, Error::Ttml(_)));
+    }
+
+    #[test]
+    fn end_ms_is_optional() {
+        let ttml = r#"<tt><body><div>
+            <p begin="00:00:01.000">no end</p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.lines[0].start_ms, 1000);
+        assert_eq!(lf.lines[0].end_ms, None);
+    }
+
+    #[test]
+    fn fallback_to_no_prefix_lang_attribute() {
+        // Some TTML producers emit `lang="en"` rather than `xml:lang="en"`.
+        let ttml = r#"<tt lang="ja"><body><div>
+            <p begin="00:00:01.000">こんにちは</p>
+        </div></body></tt>"#;
+        let lf = Lyricsfile::from_ttml(ttml, "t", "a").unwrap();
+        assert_eq!(lf.metadata.language, Some("ja".into()));
+    }
+}

--- a/crates/meedya-lyrics/tests/lyricsfile_integration.rs
+++ b/crates/meedya-lyrics/tests/lyricsfile_integration.rs
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Integration tests for the full Lyricsfile pipeline (#34).
+//
+// Per-module tests cover individual converters in isolation. These
+// tests exercise the realistic end-to-end paths a consumer (MeedyaDL,
+// MeedyaConverter) walks:
+//
+//   Apple TTML
+//      ↓ from_ttml
+//   Lyricsfile (in-memory)
+//      ↓ to_yaml
+//   YAML on disk
+//      ↓ parse
+//   Lyricsfile (back in memory)
+//      ↓ to_enhanced_lrc / to_lrc / to_srt / to_webvtt / to_ass
+//   Sidecar file(s) on disk
+//
+// They also pin the issue-#34 acceptance criteria: word-level timing
+// preserved within 1ms via TTML, 10ms via LRC, plus instrumental
+// round-trip integrity.
+
+use meedya_lyrics::{Lyricsfile, LyricsfileMetadata, LYRICSFILE_VERSION};
+
+// A representative Apple Music word-level TTML sample with two lines,
+// one with word timing and one without (mixed-shape inputs are common).
+const SAMPLE_TTML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"
+    itunes:timing="Word" xml:lang="en">
+  <body>
+    <div>
+      <p begin="00:00:01.000" end="00:00:03.500">
+        <span begin="00:00:01.000" end="00:00:01.800">Hello,</span>
+        <span begin="00:00:01.900" end="00:00:02.400">it's</span>
+        <span begin="00:00:02.500" end="00:00:03.500">me</span>
+      </p>
+      <p begin="00:00:04.000" end="00:00:06.500">I was wondering</p>
+    </div>
+  </body>
+</tt>"#;
+
+#[test]
+fn end_to_end_ttml_through_yaml_back_to_struct_preserves_word_timing() {
+    let lf = Lyricsfile::from_ttml(SAMPLE_TTML, "Hello", "Adele").expect("from_ttml");
+    let yaml = lf.to_yaml().expect("to_yaml");
+    let back = Lyricsfile::parse(&yaml).expect("parse");
+
+    // Acceptance criterion: word-level timing preserved within 1ms.
+    assert_eq!(back.lines.len(), 2);
+    let first = &back.lines[0];
+    assert_eq!(first.words.len(), 3);
+    assert!((first.words[0].start_ms - 1000).abs() <= 1);
+    assert!((first.words[1].start_ms - 1900).abs() <= 1);
+    assert!((first.words[2].start_ms - 2500).abs() <= 1);
+    assert_eq!(first.words[0].text, "Hello,");
+    assert_eq!(first.words[2].text, "me");
+
+    // Mixed-shape: second line has no word timing.
+    let second = &back.lines[1];
+    assert!(second.words.is_empty());
+    assert_eq!(second.text, "I was wondering");
+    assert_eq!(second.start_ms, 4000);
+}
+
+#[test]
+fn ttml_to_enhanced_lrc_back_to_lyricsfile_preserves_words_within_10ms() {
+    let original = Lyricsfile::from_ttml(SAMPLE_TTML, "Hello", "Adele").unwrap();
+    let enh = original.to_enhanced_lrc();
+    let recovered = Lyricsfile::from_lrc(&enh, "Hello", "Adele").unwrap();
+
+    // The LRC format is centisecond-precision, so word starts can lose
+    // up to ~10ms in the round-trip. Issue #34 acceptance criterion
+    // is 10ms tolerance for LRC paths.
+    assert_eq!(recovered.lines.len(), 2);
+    let words = &recovered.lines[0].words;
+    assert_eq!(words.len(), 3);
+    assert!((words[0].start_ms - 1000).abs() <= 10);
+    assert!((words[1].start_ms - 1900).abs() <= 10);
+    assert!((words[2].start_ms - 2500).abs() <= 10);
+}
+
+#[test]
+fn all_five_exports_produce_non_empty_output_for_sample() {
+    let lf = Lyricsfile::from_ttml(SAMPLE_TTML, "Hello", "Adele").unwrap();
+    let lrc = lf.to_lrc();
+    let enh = lf.to_enhanced_lrc();
+    let srt = lf.to_srt();
+    let vtt = lf.to_webvtt();
+    let ass = lf.to_ass();
+
+    assert!(lrc.contains("[00:01.00]"), "LRC missing timestamp: {lrc}");
+    assert!(enh.contains("<00:01.00>"), "Enhanced LRC missing word marker");
+    assert!(srt.contains("00:00:01,000 -->"), "SRT missing start");
+    assert!(vtt.starts_with("WEBVTT"), "VTT missing header");
+    assert!(ass.contains("Dialogue: 0,0:00:01.00,"), "ASS missing dialogue");
+}
+
+#[test]
+fn yaml_output_is_self_documenting_and_human_readable() {
+    // Smoke test that the YAML output looks like the format we expect a
+    // user to be willing to edit by hand. The LRCGET 2.0 release notes
+    // pitch this as a core feature.
+    let lf = Lyricsfile {
+        version: LYRICSFILE_VERSION.into(),
+        metadata: LyricsfileMetadata {
+            title: "Hello".into(),
+            artist: "Adele".into(),
+            album: Some("25".into()),
+            duration_ms: Some(295_000),
+            offset_ms: None,
+            language: Some("en".into()),
+            instrumental: false,
+        },
+        lines: vec![],
+        plain: Some("plain text fallback".into()),
+    };
+    let yaml = lf.to_yaml().unwrap();
+    // Field names should be unquoted (YAML default), values readable.
+    assert!(yaml.contains("title: Hello"));
+    assert!(yaml.contains("artist: Adele"));
+    assert!(yaml.contains("album: '25'") || yaml.contains("album: \"25\"") || yaml.contains("album: 25"));
+    assert!(yaml.contains("duration_ms: 295000"));
+    assert!(yaml.contains("language: en"));
+    assert!(yaml.contains("instrumental: false"));
+}
+
+#[test]
+fn instrumental_track_round_trips_through_yaml_and_lrc() {
+    let mut lf = Lyricsfile::new("Silent Movie", "Some Composer");
+    lf.mark_instrumental();
+    lf.metadata.album = Some("Silent Films Vol 1".into());
+
+    // YAML round-trip
+    let yaml = lf.to_yaml().unwrap();
+    let back = Lyricsfile::parse(&yaml).unwrap();
+    assert!(back.metadata.instrumental);
+    assert_eq!(back.metadata.album, Some("Silent Films Vol 1".into()));
+
+    // LRC round-trip via the instrumental marker
+    let lrc = lf.to_lrc();
+    assert!(lrc.contains("[au: instrumental]"));
+    let recovered = Lyricsfile::from_lrc(&lrc, "Silent Movie", "Some Composer").unwrap();
+    assert!(recovered.metadata.instrumental);
+    assert!(recovered.lines.is_empty());
+}
+
+#[test]
+fn empty_ttml_does_not_panic_or_emit_invalid_output() {
+    let empty = r#"<tt><body></body></tt>"#;
+    let lf = Lyricsfile::from_ttml(empty, "T", "A").unwrap();
+    let yaml = lf.to_yaml().unwrap();
+    // Must round-trip cleanly even with no lines.
+    let back = Lyricsfile::parse(&yaml).unwrap();
+    assert!(back.lines.is_empty());
+    assert!(!back.metadata.instrumental);
+}
+
+#[test]
+fn forward_compat_unknown_fields_dont_break_export() {
+    // A YAML document from a future Lyricsfile version with extra
+    // fields should still parse and export cleanly through our code.
+    let future_yaml = r#"
+version: "1.1"
+metadata:
+  title: T
+  artist: A
+  instrumental: false
+  future_metadata_field: "ignored"
+lines:
+  - text: "hi"
+    start_ms: 1000
+    end_ms: 2000
+    speaker: "ignored-future-field"
+"#;
+    let lf = Lyricsfile::parse(future_yaml).unwrap();
+    let lrc = lf.to_lrc();
+    assert!(lrc.contains("[00:01.00]hi"));
+}

--- a/crates/meedya-lyrics/tests/lyricsfile_integration.rs
+++ b/crates/meedya-lyrics/tests/lyricsfile_integration.rs
@@ -91,10 +91,16 @@ fn all_five_exports_produce_non_empty_output_for_sample() {
     let ass = lf.to_ass();
 
     assert!(lrc.contains("[00:01.00]"), "LRC missing timestamp: {lrc}");
-    assert!(enh.contains("<00:01.00>"), "Enhanced LRC missing word marker");
+    assert!(
+        enh.contains("<00:01.00>"),
+        "Enhanced LRC missing word marker"
+    );
     assert!(srt.contains("00:00:01,000 -->"), "SRT missing start");
     assert!(vtt.starts_with("WEBVTT"), "VTT missing header");
-    assert!(ass.contains("Dialogue: 0,0:00:01.00,"), "ASS missing dialogue");
+    assert!(
+        ass.contains("Dialogue: 0,0:00:01.00,"),
+        "ASS missing dialogue"
+    );
 }
 
 #[test]
@@ -120,7 +126,11 @@ fn yaml_output_is_self_documenting_and_human_readable() {
     // Field names should be unquoted (YAML default), values readable.
     assert!(yaml.contains("title: Hello"));
     assert!(yaml.contains("artist: Adele"));
-    assert!(yaml.contains("album: '25'") || yaml.contains("album: \"25\"") || yaml.contains("album: 25"));
+    assert!(
+        yaml.contains("album: '25'")
+            || yaml.contains("album: \"25\"")
+            || yaml.contains("album: 25")
+    );
     assert!(yaml.contains("duration_ms: 295000"));
     assert!(yaml.contains("language: en"));
     assert!(yaml.contains("instrumental: false"));


### PR DESCRIPTION
## Summary

Combines the implementation work from #35 (Chromaprint feature flag) and #36 (Lyricsfile YAML format) into a single PR, rebased onto the current \`main\` (post copyright-sweep \`f035bf6\`) and with the \`cargo fmt --all\` violation that broke CI on both predecessor PRs fixed.

This PR **replaces** [#35](https://github.com/MWBMPartners/MeedyaSuite-core/pull/35) and [#36](https://github.com/MWBMPartners/MeedyaSuite-core/pull/36) — both will be closed once this lands.

## Why combined

The MeedyaDL consumer (which already has its branch merged and tests passing locally) depends on **both** crates simultaneously. Merging them as one atomic unit keeps the MeedyaDL \`Cargo.toml\` dep-flip simple (one PR → two \`branch = "main"\` flips at once) and avoids a transient state where MeedyaDL points at a partially-merged upstream.

## What's in scope

### 1. Chromaprint feature flag for \`meedya-fingerprint\` (closes #10)

Adds an opt-in \`chromaprint\` cargo feature that pulls in \`rusty-chromaprint\` + \`symphonia\` + \`base64\` as **optional** deps and exposes:

\`\`\`rust
#[cfg(feature = "chromaprint")]
pub fn generate_fingerprint(
    file_path: &Path,
) -> Result<(String, u32), FingerprintError>;
\`\`\`

Returns \`(encoded_fingerprint, duration_seconds)\` where the fingerprint is URL-safe-base64 (no padding) — byte-for-byte compatible with \`fpcalc -raw -plain\` (Chromaprint's \`preset_test2\` algorithm). Pure Rust, no external binaries — preserves the ARM Linux property that lets consumer apps ship AcoustID support on platforms where no \`fpcalc\` binaries exist.

Default features stay empty, so consumers that only want the AcoustID HTTP client or the ReplayGain analyser pay **zero** compile-time / binary-size cost.

### 2. Lyricsfile (.lyrics) YAML format for \`meedya-lyrics\` (closes #34)

New module \`meedya_lyrics::lyricsfile\` mirroring LRCGET v2.0.0's reference parser byte-for-byte:

| Function | What |
|---|---|
| \`Lyricsfile::to_yaml\` / \`Lyricsfile::parse\` | YAML I/O |
| \`Lyricsfile::from_ttml\` | Apple Music TTML → Lyricsfile (preserves word-level timing within 1ms) |
| \`Lyricsfile::from_lrc\` | Standard LRC / Enhanced LRC → Lyricsfile |
| \`Lyricsfile::to_lrc\` / \`to_enhanced_lrc\` / \`to_srt\` / \`to_webvtt\` / \`to_ass\` | Five reverse exporters |
| \`Lyricsfile::mark_instrumental\` / \`has_word_level_timing\` | helpers |

Public constants: \`LYRICSFILE_VERSION = "1.0"\`, \`INSTRUMENTAL_MARKER = "[au: instrumental]"\`.

Forward-compat policy: every optional field is \`#[serde(skip_serializing_if = "Option::is_none")]\` on write and \`#[serde(default)]\` on read; unknown fields silently ignored at parse time. A future v1.1 file still parses through v1.0 code (pinned by the \`forward_compat_*\` tests).

### 3. Commit history (9 commits total)

| Commit | Scope |
|---|---|
| \`416106e\` | meedya-lyrics: workspace deps for Lyricsfile (\`serde_yaml\`, \`quick-xml\`) |
| \`ea0ce2c\` | meedya-lyrics: core Lyricsfile structs + YAML parse/to_yaml |
| \`4c3bd7b\` | meedya-lyrics: TTML → Lyricsfile converter |
| \`5e52159\` | meedya-lyrics: LRC → Lyricsfile converter |
| \`f5dd67c\` | meedya-lyrics: 5 reverse exporters |
| \`8acb995\` | meedya-lyrics: cross-format integration tests + lib.rs docs |
| \`d4009bb\` | meedya-fingerprint: chromaprint feature flag + optional deps |
| \`6a84313\` | meedya-fingerprint: \`chromaprint::generate_fingerprint\` module |
| \`021fc62\` | \`cargo fmt --all\` + copyright header normalisation (fixes CI fmt-check failure) |

## CI status — verified locally with the exact workflow commands

| Check | Result |
|---|---|
| \`cargo fmt --all -- --check\` | ✅ clean |
| \`cargo test --workspace --all-features --locked\` | ✅ **322 passing**, 0 failed, 1 ignored |
| \`cargo clippy --workspace --all-targets --all-features -- -W clippy::all\` | ✅ informational only (pre-existing meedya-codecs warnings, not new) |

Per-crate test breakdown:

| Crate | Tests |
|---|---|
| meedya-codecs | 47 |
| meedya-db | 3 |
| meedya-fingerprint (with \`chromaprint\`) | 11 (was 6 without the feature) |
| meedya-library-import | 30 |
| meedya-lyrics | 76 lib + 7 integration |
| meedya-metadata | 59 |
| meedya-providers | 27 |
| meedya-tags-extended | 61 |

## Consumer migration path

MeedyaDL's [\`feat/871-library-enrichment-skip\`](https://github.com/MWBMPartners/MeedyaDL/tree/feat/871-library-enrichment-skip) branch (also pushed, 35 commits) consumes this work via:

\`\`\`toml
meedya-fingerprint = { git = "...", branch = "feat/353-chromaprint-feature-flag", features = ["chromaprint"] }
meedya-lyrics      = { git = "...", branch = "feat/596-lyricsfile-yaml-format" }
\`\`\`

Once this PR merges, both deps flip to \`branch = "main"\` in a one-line MeedyaDL follow-up commit. The MeedyaDL side already runs **1281/1281 tests passing** against this branch's commits.

## What's NOT in this PR

- **Real-audio round-trip fingerprint test** for chromaprint — needs bundling a small (~50KB) audio fixture. Worth filing as a separate follow-up issue. End-to-end real-data coverage is provided by MeedyaDL running its enrichment pipeline against actual Apple Music content.
- **LRCLIB Lyricsfile ingestion** — \`provider::lrclib\` stays LRC-only until LRCLIB's API exposes the YAML format. Separate consumer issue when that lands.
- **Embedding Lyricsfile into MP4 freeform atoms** — file-on-disk sidecar only for v1. Embed-as-blob can come later if a player needs it.

Closes #10, closes #34.