### PR TITLE
feat(providers): port 13 concrete provider implementations from MeedyaManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +188,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "dashmap"
@@ -197,6 +225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -406,6 +444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -810,6 +858,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,7 +989,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -954,7 +1019,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -969,7 +1034,7 @@ dependencies = [
  "serde",
  "serde_json",
  "symphonia",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -994,7 +1059,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -1009,7 +1074,7 @@ dependencies = [
  "mp4ameta",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
 ]
 
@@ -1020,13 +1085,15 @@ dependencies = [
  "async-trait",
  "fuzzy-matcher",
  "governor",
+ "jsonwebtoken",
  "keyring",
  "meedya-codecs",
+ "oauth2",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1109,6 +1176,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1216,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -1236,6 +1333,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1374,7 +1481,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1395,7 +1502,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1786,6 +1893,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1938,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,10 +1965,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -2174,11 +2324,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2452,6 +2622,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2661,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2498,6 +2675,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -3116,6 +3299,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/meedya-codecs/src/container.rs
+++ b/crates/meedya-codecs/src/container.rs
@@ -470,12 +470,7 @@ impl ContainerFormat {
         let ext_lower = ext_lower.strip_prefix('.').unwrap_or(&ext_lower);
 
         use strum::IntoEnumIterator;
-        for fmt in Self::iter() {
-            if fmt.extensions().iter().any(|e| *e == ext_lower) {
-                return Some(fmt);
-            }
-        }
-        None
+        Self::iter().find(|fmt| fmt.extensions().contains(&ext_lower))
     }
 }
 

--- a/crates/meedya-providers/Cargo.toml
+++ b/crates/meedya-providers/Cargo.toml
@@ -26,6 +26,49 @@ tempfile = { workspace = true }
 default = []
 keyring-credentials = ["dep:keyring"]
 
+# Per-provider features. Each adds a single provider module under
+# `providers/<name>.rs`. Apps opt into only what they need; the default
+# feature set ships ZERO providers so a consumer that just wants the
+# `MetadataProvider` trait + infrastructure has no extra build cost.
+provider-musicbrainz    = []
+provider-spotify        = ["dep:oauth2"]
+provider-apple-music    = ["dep:jsonwebtoken"]
+provider-deezer         = []
+provider-tmdb           = []
+provider-thetvdb        = []
+provider-omdb           = []
+provider-apple-tv       = []
+provider-itunes-store   = []
+provider-apple-podcasts = []
+provider-isrc           = []
+provider-eidr           = []
+provider-iswc           = []
+
+# Convenience: enable all real providers in one go.
+provider-all = [
+    "provider-musicbrainz",
+    "provider-spotify",
+    "provider-apple-music",
+    "provider-deezer",
+    "provider-tmdb",
+    "provider-thetvdb",
+    "provider-omdb",
+    "provider-apple-tv",
+    "provider-itunes-store",
+    "provider-apple-podcasts",
+    "provider-isrc",
+    "provider-eidr",
+    "provider-iswc",
+]
+
 [dependencies.keyring]
 version = "3"
+optional = true
+
+[dependencies.oauth2]
+version = "5"
+optional = true
+
+[dependencies.jsonwebtoken]
+version = "10"
 optional = true

--- a/crates/meedya-providers/src/cover_art.rs
+++ b/crates/meedya-providers/src/cover_art.rs
@@ -1,4 +1,19 @@
-use crate::types::CoverArtInfo;
+use crate::types::{CoverArtInfo, ProviderResult};
+
+/// Returns the cover art entry with the most pixels (width × height).
+///
+/// Entries with missing `width` or `height` are treated as zero pixels.
+/// Returns `None` if the result has no cover art at all.
+pub fn best_cover_art(r: &ProviderResult) -> Option<&CoverArtInfo> {
+    r.cover_art
+        .iter()
+        .max_by_key(|a| u64::from(a.width.unwrap_or(0)) * u64::from(a.height.unwrap_or(0)))
+}
+
+/// Returns `true` if the result has at least one cover art entry.
+pub fn has_cover_art(r: &ProviderResult) -> bool {
+    !r.cover_art.is_empty()
+}
 
 /// Size classification for cover art.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/meedya-providers/src/extra_keys.rs
+++ b/crates/meedya-providers/src/extra_keys.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Standard metadata keys for fields not natively on `ProviderResult`.
+//
+// Provider implementations use these constants when populating the
+// `result.metadata: HashMap<String, serde_json::Value>` blob, so downstream
+// consumers can rely on a consistent set of well-known keys rather than each
+// provider inventing its own naming.
+//
+// These keys carry data the upstream `ProviderResult` struct does not model
+// directly: things like album-artist (distinct from track artist), the total
+// number of tracks on an album, ISWC / EIDR identifiers, content-advisory
+// flags, duration in seconds, BPM, and the provider's internal item ID.
+//
+// Ported from MeedyaManager `mm-providers` under issue #136 /
+// MeedyaSuite-core#12 (the bare upstream names drop the `META_` prefix the
+// MM constants used).
+
+/// Album artist (when different from the track artist). Stored as `Value::String`.
+pub const ALBUM_ARTIST: &str = "album_artist";
+
+/// Total tracks on the album. Stored as `Value::Number(u32)`.
+pub const TRACK_TOTAL: &str = "track_total";
+
+/// ISWC (composition identifier). Stored as `Value::String`.
+pub const ISWC: &str = "iswc";
+
+/// EIDR (video identifier). Stored as `Value::String`.
+pub const EIDR: &str = "eidr";
+
+/// Content advisory label ("explicit", "clean", "PG-13", etc.). Stored as `Value::String`.
+pub const CONTENT_ADVISORY: &str = "content_advisory";
+
+/// Duration in seconds. Stored as `Value::Number(f64)`.
+pub const DURATION_SECS: &str = "duration_secs";
+
+/// Beats per minute. Stored as `Value::Number(f64)`.
+pub const BPM: &str = "bpm";
+
+/// Provider-specific item identifier. Stored as `Value::String`.
+pub const PROVIDER_ID: &str = "provider_id";

--- a/crates/meedya-providers/src/lib.rs
+++ b/crates/meedya-providers/src/lib.rs
@@ -12,15 +12,36 @@
 pub mod cover_art;
 pub mod credentials;
 pub mod error;
+pub mod extra_keys;
 pub mod match_scoring;
 pub mod rate_limiter;
 pub mod traits;
 pub mod types;
 
-pub use cover_art::CoverArtSize;
+// Conditionally compiled provider implementations — each gated behind its
+// own `provider-<name>` Cargo feature so downstream apps can opt into only
+// the providers they need.
+#[cfg(any(
+    feature = "provider-musicbrainz",
+    feature = "provider-spotify",
+    feature = "provider-apple-music",
+    feature = "provider-deezer",
+    feature = "provider-tmdb",
+    feature = "provider-thetvdb",
+    feature = "provider-omdb",
+    feature = "provider-apple-tv",
+    feature = "provider-itunes-store",
+    feature = "provider-apple-podcasts",
+    feature = "provider-isrc",
+    feature = "provider-eidr",
+    feature = "provider-iswc",
+))]
+pub mod providers;
+
+pub use cover_art::{best_cover_art, has_cover_art, CoverArtSize};
 pub use credentials::{CredentialSource, CredentialStore, ResolvedCredential};
 pub use error::CredentialError;
 pub use match_scoring::{MatchScorer, ScoringWeights};
 pub use rate_limiter::{ProviderRateLimiter, RateLimiterRegistry};
-pub use traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+pub use traits::{is_retryable, MetadataProvider, ProviderCapabilities, ProviderError};
 pub use types::{CoverArtInfo, MediaType, ProviderResult, SearchQuery};

--- a/crates/meedya-providers/src/providers/apple_music.rs
+++ b/crates/meedya-providers/src/providers/apple_music.rs
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Apple Music metadata provider (iTunes Search API).
+// Ported from MeedyaManager crates/mm-providers/src/music/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{CONTENT_ADVISORY, DURATION_SECS, PROVIDER_ID, TRACK_TOTAL};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+fn search_term_fallback(query: &SearchQuery) -> String {
+    let combined = format!(
+        "{} {}",
+        query.title.as_deref().unwrap_or(""),
+        query.artist.as_deref().unwrap_or("")
+    );
+    combined.trim().to_owned()
+}
+
+fn insert_duration(result: &mut ProviderResult, secs: f64) {
+    if let Some(num) = serde_json::Number::from_f64(secs) {
+        result
+            .metadata
+            .insert(DURATION_SECS.into(), Value::Number(num));
+    }
+}
+
+/// Searches via the iTunes Search API (no auth required for basic track search).
+///
+/// Endpoint: `https://itunes.apple.com/search`
+/// Auth:     None (JWT for full Apple Music API path remains stubbed)
+/// Limits:   20 RPM (conservative; Apple does not publish limits)
+pub struct AppleMusicProvider {
+    client: Client,
+    base_url: String,
+    enabled: bool,
+    country: String,
+}
+
+impl AppleMusicProvider {
+    /// Create an Apple Music provider. The iTunes Search API is always available (no auth).
+    pub fn new(country: impl Into<String>) -> Self {
+        Self::with_base_url(country, "https://itunes.apple.com")
+    }
+
+    pub fn with_base_url(country: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            enabled: true,
+            country: country.into(),
+        }
+    }
+
+    fn parse_itunes(provider_name: &str, body: &str) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesResponse {
+            results: Vec<ItunesTrack>,
+        }
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesTrack {
+            track_id: Option<u64>,
+            track_name: Option<String>,
+            artist_name: Option<String>,
+            collection_name: Option<String>,
+            artwork_url100: Option<String>,
+            release_date: Option<String>,
+            track_number: Option<u32>,
+            track_count: Option<u32>,
+            disc_number: Option<u32>,
+            primary_genre_name: Option<String>,
+            track_time_millis: Option<u64>,
+            explicit_ness: Option<String>,
+        }
+
+        let resp: ItunesResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("iTunes response", e))?;
+
+        let results = resp
+            .results
+            .into_iter()
+            .map(|t| {
+                let cover_art = t
+                    .artwork_url100
+                    .as_deref()
+                    .map(|url| {
+                        // Replace 100x100 with higher-res variant
+                        let hires = url.replace("100x100", "3000x3000");
+                        vec![
+                            CoverArtInfo {
+                                url: hires,
+                                width: Some(3000),
+                                height: Some(3000),
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                            CoverArtInfo {
+                                url: url.to_owned(),
+                                width: Some(100),
+                                height: Some(100),
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                        ]
+                    })
+                    .unwrap_or_default();
+
+                let year = t
+                    .release_date
+                    .as_deref()
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+
+                let content_advisory = t.explicit_ness.as_deref().map(|e| {
+                    if e.to_lowercase() == "explicit" {
+                        "explicit"
+                    } else {
+                        "clean"
+                    }
+                    .to_owned()
+                });
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = t.track_name;
+                result.artist = t.artist_name;
+                result.album = t.collection_name;
+                result.year = year;
+                result.track_number = t.track_number;
+                result.disc_number = t.disc_number;
+                result.genre = t.primary_genre_name;
+                result.cover_art = cover_art;
+
+                if let Some(id) = t.track_id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id.to_string()));
+                }
+                if let Some(total) = t.track_count {
+                    result
+                        .metadata
+                        .insert(TRACK_TOTAL.into(), Value::Number(total.into()));
+                }
+                if let Some(ms) = t.track_time_millis {
+                    insert_duration(&mut result, ms as f64 / 1000.0);
+                }
+                if let Some(advisory) = content_advisory {
+                    result
+                        .metadata
+                        .insert(CONTENT_ADVISORY.into(), Value::String(advisory));
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for AppleMusicProvider {
+    fn id(&self) -> &str {
+        "apple_music"
+    }
+
+    fn display_name(&self) -> &str {
+        "Apple Music"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: true,
+            video_search: false,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.enabled {
+            return Err(ProviderError::NotConfigured("apple_music".into()));
+        }
+
+        let search_term = if let Some(title) = &query.title {
+            if let Some(artist) = &query.artist {
+                format!("{title} {artist}")
+            } else {
+                title.clone()
+            }
+        } else {
+            search_term_fallback(query)
+        };
+
+        let url = format!("{}/search", self.base_url);
+        debug!(
+            provider = "apple_music",
+            term = &search_term,
+            "Sending iTunes search request"
+        );
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("term", &search_term),
+                ("media", &"music".to_owned()),
+                ("entity", &"song".to_owned()),
+                ("country", &self.country),
+                ("limit", &limit),
+            ])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            return Err(ProviderError::NetworkError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_itunes("apple_music", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apple_music_name() {
+        let p = AppleMusicProvider::new("US");
+        assert_eq!(p.id(), "apple_music");
+    }
+
+    #[test]
+    fn apple_music_capabilities_provides_cover_art() {
+        let p = AppleMusicProvider::new("US");
+        assert!(p.capabilities().cover_art);
+    }
+
+    #[test]
+    fn apple_music_parse_itunes_valid_json() {
+        let json = r#"{
+            "results": [{
+                "trackId": 123456,
+                "trackName": "Yesterday",
+                "artistName": "The Beatles",
+                "collectionName": "Help!",
+                "artworkUrl100": "https://is1.mzstatic.com/100x100.jpg",
+                "releaseDate": "1965-08-06T00:00:00Z",
+                "trackNumber": 10,
+                "trackCount": 14,
+                "discNumber": 1,
+                "primaryGenreName": "Rock",
+                "trackTimeMillis": 125000
+            }]
+        }"#;
+        let results = AppleMusicProvider::parse_itunes("apple_music", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Yesterday"));
+        assert_eq!(results[0].artist.as_deref(), Some("The Beatles"));
+        assert_eq!(results[0].year, Some(1965));
+        assert_eq!(results[0].genre.as_deref(), Some("Rock"));
+        assert_eq!(results[0].track_number, Some(10));
+        // Track total now in metadata
+        assert_eq!(
+            results[0]
+                .metadata
+                .get(TRACK_TOTAL)
+                .and_then(serde_json::Value::as_u64),
+            Some(14)
+        );
+        // Cover art: hi-res + thumbnail
+        assert_eq!(results[0].cover_art.len(), 2);
+    }
+
+    #[test]
+    fn apple_music_parse_hi_res_url_generated() {
+        let json = r#"{
+            "results": [{"artworkUrl100": "https://x.com/100x100.jpg"}]
+        }"#;
+        let results = AppleMusicProvider::parse_itunes("apple_music", json).unwrap();
+        let largest = results[0]
+            .cover_art
+            .iter()
+            .max_by_key(|a| u64::from(a.width.unwrap_or(0)) * u64::from(a.height.unwrap_or(0)));
+        assert!(largest.unwrap().url.contains("3000x3000"));
+    }
+
+    #[test]
+    fn apple_music_parse_empty_results() {
+        let json = r#"{"results": []}"#;
+        let results = AppleMusicProvider::parse_itunes("apple_music", json).unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/meedya-providers/src/providers/apple_podcasts.rs
+++ b/crates/meedya-providers/src/providers/apple_podcasts.rs
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Apple Podcasts metadata provider (iTunes Search API — podcast entity).
+// Ported from MeedyaManager crates/mm-providers/src/podcasts/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::PROVIDER_ID;
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+/// Searches Apple Podcasts via the iTunes Search API.
+///
+/// Endpoint: `https://itunes.apple.com/search?media=podcast`
+/// Auth:     None (public API)
+/// Limits:   20 RPM (conservative)
+pub struct ApplePodcastsProvider {
+    client: Client,
+    base_url: String,
+    /// Whether the provider should respond to queries (test hook).
+    pub(crate) enabled: bool,
+    country: String,
+}
+
+impl ApplePodcastsProvider {
+    /// Create a new Apple Podcasts provider for the given country code (ISO 3166-1 alpha-2).
+    pub fn new(country: impl Into<String>) -> Self {
+        Self::with_base_url(country, "https://itunes.apple.com")
+    }
+
+    /// Create a provider with a custom base URL (for test mocking).
+    pub fn with_base_url(country: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            enabled: true,
+            country: country.into(),
+        }
+    }
+
+    /// Parse an iTunes podcast search response into `ProviderResult`s.
+    pub(crate) fn parse_podcasts(
+        provider_name: &str,
+        body: &str,
+    ) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesPodcastResponse {
+            results: Vec<ItunesPodcastResult>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesPodcastResult {
+            collection_id: Option<u64>,
+            collection_name: Option<String>,
+            artist_name: Option<String>,
+            artwork_url600: Option<String>,
+            artwork_url100: Option<String>,
+            release_date: Option<String>,
+            primary_genre_name: Option<String>,
+            track_count: Option<u32>,
+            feed_url: Option<String>,
+            collection_view_url: Option<String>,
+        }
+
+        let resp: ItunesPodcastResponse = serde_json::from_str(body).map_err(|e| {
+            ProviderError::Other(format!("parse error: Apple Podcasts response: {e}"))
+        })?;
+
+        let results = resp
+            .results
+            .into_iter()
+            .map(|r| {
+                // Prefer 600px cover, fall back to 100px
+                let mut cover_art = Vec::new();
+                if let Some(url) = &r.artwork_url600 {
+                    cover_art.push(CoverArtInfo {
+                        url: url.clone(),
+                        width: Some(600),
+                        height: Some(600),
+                        mime_type: Some("image/jpeg".into()),
+                    });
+                }
+                if let Some(url) = &r.artwork_url100 {
+                    cover_art.push(CoverArtInfo {
+                        url: url.clone(),
+                        width: Some(100),
+                        height: Some(100),
+                        mime_type: Some("image/jpeg".into()),
+                    });
+                }
+
+                let year = r
+                    .release_date
+                    .as_deref()
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = r.collection_name; // Podcast name
+                result.artist = r.artist_name; // Podcast author / network
+                result.genre = r.primary_genre_name;
+                result.year = year;
+                result.cover_art = cover_art;
+
+                // Provider-specific identifiers go into metadata
+                if let Some(id) = r.collection_id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id.to_string()));
+                }
+                if let Some(feed) = &r.feed_url {
+                    result
+                        .metadata
+                        .insert("feed_url".into(), Value::String(feed.clone()));
+                }
+                if let Some(view_url) = &r.collection_view_url {
+                    result
+                        .metadata
+                        .insert("podcast_url".into(), Value::String(view_url.clone()));
+                }
+                if let Some(count) = r.track_count {
+                    result
+                        .metadata
+                        .insert("episode_count".into(), Value::Number(count.into()));
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+impl Default for ApplePodcastsProvider {
+    fn default() -> Self {
+        Self::new("US")
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for ApplePodcastsProvider {
+    fn id(&self) -> &str {
+        "apple_podcasts"
+    }
+
+    fn display_name(&self) -> &str {
+        "Apple Podcasts"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: false,
+            video_search: false,
+            podcast_search: true,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.enabled {
+            return Err(ProviderError::NotConfigured("apple_podcasts".into()));
+        }
+
+        // Build a free-text term from title or artist (no upstream `query` field).
+        let fallback = format!(
+            "{} {}",
+            query.title.as_deref().unwrap_or(""),
+            query.artist.as_deref().unwrap_or("")
+        );
+        let fallback_trimmed = fallback.trim();
+        let term: &str = query
+            .title
+            .as_deref()
+            .or(query.artist.as_deref())
+            .unwrap_or(fallback_trimmed);
+
+        debug!(
+            provider = "apple_podcasts",
+            term = term,
+            "Sending iTunes podcast search request"
+        );
+
+        let limit = query.max_results.unwrap_or(20).to_string();
+        let url = format!("{}/search", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("term", term),
+                ("media", "podcast"),
+                ("entity", "podcast"),
+                ("country", &self.country),
+                ("limit", &limit),
+            ])
+            .send()
+            .await
+            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(ProviderError::NetworkError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body = response
+            .text()
+            .await
+            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+        Self::parse_podcasts("apple_podcasts", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apple_podcasts_name() {
+        assert_eq!(ApplePodcastsProvider::new("US").id(), "apple_podcasts");
+    }
+
+    #[test]
+    fn apple_podcasts_display_name() {
+        assert_eq!(
+            ApplePodcastsProvider::new("US").display_name(),
+            "Apple Podcasts"
+        );
+    }
+
+    #[test]
+    fn apple_podcasts_capabilities_podcast() {
+        let caps = ApplePodcastsProvider::new("US").capabilities();
+        assert!(caps.podcast_search);
+        assert!(!caps.music_search);
+        assert!(caps.cover_art);
+    }
+
+    #[test]
+    fn apple_podcasts_parse_valid_json() {
+        let json = r#"{
+            "results": [{
+                "collectionId": 12345678,
+                "collectionName": "The Daily",
+                "artistName": "The New York Times",
+                "artworkUrl600": "https://is1.mzstatic.com/600x600.jpg",
+                "artworkUrl100": "https://is1.mzstatic.com/100x100.jpg",
+                "releaseDate": "2024-01-15T00:00:00Z",
+                "primaryGenreName": "News",
+                "trackCount": 2500,
+                "feedUrl": "https://feeds.nytimes.com/thedaily",
+                "collectionViewUrl": "https://podcasts.apple.com/us/podcast/the-daily/id1200361736"
+            }]
+        }"#;
+        let results = ApplePodcastsProvider::parse_podcasts("apple_podcasts", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("The Daily"));
+        assert_eq!(results[0].artist.as_deref(), Some("The New York Times"));
+        assert_eq!(results[0].year, Some(2024));
+        assert_eq!(results[0].genre.as_deref(), Some("News"));
+        assert_eq!(
+            results[0]
+                .metadata
+                .get(PROVIDER_ID)
+                .and_then(|v| v.as_str()),
+            Some("12345678")
+        );
+        // Both cover art sizes present
+        assert_eq!(results[0].cover_art.len(), 2);
+        // Extra fields stored in metadata
+        assert!(results[0].metadata.contains_key("feed_url"));
+        assert!(results[0].metadata.contains_key("episode_count"));
+        assert_eq!(
+            results[0]
+                .metadata
+                .get("episode_count")
+                .and_then(serde_json::Value::as_u64),
+            Some(2500)
+        );
+    }
+
+    #[test]
+    fn apple_podcasts_parse_empty_results() {
+        let json = r#"{"results": []}"#;
+        let results = ApplePodcastsProvider::parse_podcasts("apple_podcasts", json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn apple_podcasts_parse_invalid_json_returns_err() {
+        let result = ApplePodcastsProvider::parse_podcasts("apple_podcasts", "bad json");
+        assert!(matches!(result, Err(ProviderError::Other(_))));
+    }
+
+    #[test]
+    fn apple_podcasts_parse_600px_art_preferred() {
+        let json = r#"{
+            "results": [{
+                "artworkUrl600": "https://x.com/big.jpg",
+                "artworkUrl100": "https://x.com/small.jpg"
+            }]
+        }"#;
+        let results = ApplePodcastsProvider::parse_podcasts("apple_podcasts", json).unwrap();
+        let largest = results[0]
+            .cover_art
+            .iter()
+            .max_by_key(|a| u64::from(a.width.unwrap_or(0)) * u64::from(a.height.unwrap_or(0)))
+            .unwrap();
+        assert_eq!(largest.width, Some(600));
+    }
+
+    #[test]
+    fn apple_podcasts_parse_missing_artwork_produces_no_cover_art() {
+        let json = r#"{"results": [{"collectionName": "My Podcast"}]}"#;
+        let results = ApplePodcastsProvider::parse_podcasts("apple_podcasts", json).unwrap();
+        assert!(results[0].cover_art.is_empty());
+    }
+
+    #[test]
+    fn apple_podcasts_parse_no_feed_url_skips_extra() {
+        let json = r#"{"results": [{"collectionName": "Podcast"}]}"#;
+        let results = ApplePodcastsProvider::parse_podcasts("apple_podcasts", json).unwrap();
+        assert!(!results[0].metadata.contains_key("feed_url"));
+    }
+
+    #[tokio::test]
+    async fn apple_podcasts_search_disabled_returns_err() {
+        let mut p = ApplePodcastsProvider::new("US");
+        p.enabled = false;
+        let q = SearchQuery {
+            title: Some("Test".into()),
+            max_results: Some(5),
+            ..Default::default()
+        };
+        assert!(matches!(
+            p.search(&q).await,
+            Err(ProviderError::NotConfigured(_))
+        ));
+    }
+}

--- a/crates/meedya-providers/src/providers/apple_tv.rs
+++ b/crates/meedya-providers/src/providers/apple_tv.rs
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Apple TV metadata provider (iTunes Search API — movie entity).
+// Ported from MeedyaManager crates/mm-providers/src/video/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{CONTENT_ADVISORY, DURATION_SECS, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+fn insert_duration(result: &mut ProviderResult, secs: f64) {
+    if let Some(num) = serde_json::Number::from_f64(secs) {
+        result
+            .metadata
+            .insert(DURATION_SECS.into(), Value::Number(num));
+    }
+}
+
+/// Searches Apple TV via the iTunes Search API for films and TV episodes.
+///
+/// Endpoint: `https://itunes.apple.com/search?media=movie`
+/// Auth:     None (public API)
+/// Limits:   20 RPM (conservative)
+pub struct AppleTvProvider {
+    client: Client,
+    base_url: String,
+    enabled: bool,
+    country: String,
+}
+
+impl AppleTvProvider {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self::with_base_url(country, "https://itunes.apple.com")
+    }
+
+    pub fn with_base_url(country: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            enabled: true,
+            country: country.into(),
+        }
+    }
+
+    pub(crate) fn parse_itunes_video(
+        provider_name: &str,
+        body: &str,
+    ) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesVideoResponse {
+            results: Vec<ItunesVideoResult>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesVideoResult {
+            track_id: Option<u64>,
+            track_name: Option<String>,
+            artist_name: Option<String>, // Director for movies
+            collection_name: Option<String>,
+            artwork_url100: Option<String>,
+            release_date: Option<String>,
+            track_time_millis: Option<u64>,
+            primary_genre_name: Option<String>,
+            content_advisory_rating: Option<String>,
+        }
+
+        let resp: ItunesVideoResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("Apple TV response", e))?;
+
+        let results = resp
+            .results
+            .into_iter()
+            .map(|r| {
+                let year = r
+                    .release_date
+                    .as_deref()
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+                let cover_art = r
+                    .artwork_url100
+                    .as_deref()
+                    .map(|url| {
+                        let hires = url.replace("100x100", "600x600");
+                        vec![
+                            CoverArtInfo {
+                                url: hires,
+                                width: Some(600),
+                                height: Some(600),
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                            CoverArtInfo {
+                                url: url.to_owned(),
+                                width: Some(100),
+                                height: Some(100),
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                        ]
+                    })
+                    .unwrap_or_default();
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = r.track_name;
+                result.artist = r.artist_name; // Director for films
+                result.album = r.collection_name; // Series name for TV episodes
+                result.year = year;
+                result.genre = r.primary_genre_name;
+                result.cover_art = cover_art;
+
+                if let Some(id) = r.track_id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id.to_string()));
+                }
+                if let Some(ms) = r.track_time_millis {
+                    insert_duration(&mut result, ms as f64 / 1000.0);
+                }
+                if let Some(advisory) = r.content_advisory_rating {
+                    result
+                        .metadata
+                        .insert(CONTENT_ADVISORY.into(), Value::String(advisory));
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+impl Default for AppleTvProvider {
+    fn default() -> Self {
+        Self::new("US")
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for AppleTvProvider {
+    fn id(&self) -> &str {
+        "apple_tv"
+    }
+
+    fn display_name(&self) -> &str {
+        "Apple TV"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: false,
+            video_search: true,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.enabled {
+            return Err(ProviderError::NotConfigured("apple_tv".into()));
+        }
+        let fallback = format!(
+            "{} {}",
+            query.title.as_deref().unwrap_or(""),
+            query.artist.as_deref().unwrap_or("")
+        );
+        let term: &str = query.title.as_deref().unwrap_or(fallback.trim());
+        debug!(
+            provider = "apple_tv",
+            term = term,
+            "Sending iTunes video search request"
+        );
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let url = format!("{}/search", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("term", term),
+                ("media", "movie"),
+                ("country", &self.country),
+                ("limit", &limit),
+            ])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            return Err(ProviderError::NetworkError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_itunes_video("apple_tv", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apple_tv_name() {
+        assert_eq!(AppleTvProvider::new("US").id(), "apple_tv");
+    }
+
+    #[test]
+    fn apple_tv_capabilities_video_type() {
+        assert!(AppleTvProvider::default().capabilities().video_search);
+    }
+
+    #[test]
+    fn apple_tv_parse_itunes_video_valid_json() {
+        let json = r#"{
+            "results": [{
+                "trackId": 1234,
+                "trackName": "Interstellar",
+                "artistName": "Christopher Nolan",
+                "collectionName": null,
+                "artworkUrl100": "https://is1.mzstatic.com/100x100.jpg",
+                "releaseDate": "2014-11-07T00:00:00Z",
+                "trackTimeMillis": 9720000,
+                "primaryGenreName": "Sci-Fi",
+                "contentAdvisoryRating": "PG-13"
+            }]
+        }"#;
+        let results = AppleTvProvider::parse_itunes_video("apple_tv", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Interstellar"));
+        assert_eq!(results[0].artist.as_deref(), Some("Christopher Nolan")); // Director
+        assert_eq!(results[0].year, Some(2014));
+        assert_eq!(results[0].genre.as_deref(), Some("Sci-Fi"));
+        assert_eq!(
+            results[0]
+                .metadata
+                .get(CONTENT_ADVISORY)
+                .and_then(serde_json::Value::as_str),
+            Some("PG-13")
+        );
+        assert_eq!(results[0].cover_art.len(), 2);
+    }
+
+    #[test]
+    fn apple_tv_parse_empty_results() {
+        let json = r#"{"results": []}"#;
+        let results = AppleTvProvider::parse_itunes_video("apple_tv", json).unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/meedya-providers/src/providers/deezer.rs
+++ b/crates/meedya-providers/src/providers/deezer.rs
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Deezer metadata provider.
+// Ported from MeedyaManager crates/mm-providers/src/music/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{CONTENT_ADVISORY, DURATION_SECS, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+fn search_term(query: &SearchQuery) -> String {
+    let combined = format!(
+        "{} {}",
+        query.title.as_deref().unwrap_or(""),
+        query.artist.as_deref().unwrap_or("")
+    );
+    combined.trim().to_owned()
+}
+
+fn insert_duration(result: &mut ProviderResult, secs: f64) {
+    if let Some(num) = serde_json::Number::from_f64(secs) {
+        result
+            .metadata
+            .insert(DURATION_SECS.into(), Value::Number(num));
+    }
+}
+
+/// Searches the Deezer public API (no auth required).
+///
+/// Endpoint: `https://api.deezer.com/search`
+/// Auth:     None
+/// Limits:   50 RPM
+pub struct DeezerProvider {
+    client: Client,
+    base_url: String,
+    enabled: bool,
+}
+
+impl DeezerProvider {
+    pub fn new() -> Self {
+        Self::with_base_url("https://api.deezer.com")
+    }
+
+    pub fn with_base_url(base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            enabled: true,
+        }
+    }
+
+    fn parse_deezer(provider_name: &str, body: &str) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        struct DeezerResponse {
+            data: Vec<DeezerTrack>,
+        }
+        #[derive(Deserialize)]
+        struct DeezerTrack {
+            id: Option<u64>,
+            title: Option<String>,
+            artist: Option<DeezerArtist>,
+            album: Option<DeezerAlbum>,
+            duration: Option<u64>,
+            isrc: Option<String>,
+            explicit_lyrics: Option<bool>,
+            rank: Option<u64>,
+        }
+        #[derive(Deserialize)]
+        struct DeezerArtist {
+            name: Option<String>,
+        }
+        #[derive(Deserialize)]
+        struct DeezerAlbum {
+            title: Option<String>,
+            cover_xl: Option<String>,
+            cover_medium: Option<String>,
+        }
+
+        let resp: DeezerResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("Deezer response", e))?;
+
+        let results = resp
+            .data
+            .into_iter()
+            .map(|t| {
+                let mut cover_art = Vec::new();
+                if let Some(xl) = t.album.as_ref().and_then(|a| a.cover_xl.as_deref()) {
+                    cover_art.push(CoverArtInfo {
+                        url: xl.to_owned(),
+                        width: Some(1000),
+                        height: Some(1000),
+                        mime_type: Some("image/jpeg".into()),
+                    });
+                }
+                if let Some(med) = t.album.as_ref().and_then(|a| a.cover_medium.as_deref()) {
+                    cover_art.push(CoverArtInfo {
+                        url: med.to_owned(),
+                        width: Some(250),
+                        height: Some(250),
+                        mime_type: Some("image/jpeg".into()),
+                    });
+                }
+
+                // Deezer rank is up to ~100_000; normalise to [0.0, 1.0]
+                let score = t
+                    .rank
+                    .map_or(0.5, |r| (r as f64 / 100_000.0).clamp(0.0, 1.0));
+
+                let content_advisory = if t.explicit_lyrics.unwrap_or(false) {
+                    "explicit"
+                } else {
+                    "clean"
+                };
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = t.title;
+                result.artist = t.artist.and_then(|a| a.name);
+                result.album = t.album.and_then(|a| a.title);
+                result.isrc = t.isrc;
+                result.score = score;
+                result.cover_art = cover_art;
+                result.metadata.insert(
+                    CONTENT_ADVISORY.into(),
+                    Value::String(content_advisory.into()),
+                );
+                if let Some(id) = t.id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id.to_string()));
+                }
+                if let Some(secs) = t.duration {
+                    insert_duration(&mut result, secs as f64);
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+impl Default for DeezerProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for DeezerProvider {
+    fn id(&self) -> &str {
+        "deezer"
+    }
+
+    fn display_name(&self) -> &str {
+        "Deezer"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: true,
+            video_search: false,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.enabled {
+            return Err(ProviderError::NotConfigured("deezer".into()));
+        }
+
+        // Deezer supports ISRC lookup via `/track/isrc:<isrc>`
+        let url = if let Some(isrc) = &query.isrc {
+            format!("{}/track/isrc:{isrc}", self.base_url)
+        } else {
+            format!("{}/search", self.base_url)
+        };
+
+        let q = if query.isrc.is_some() {
+            None
+        } else {
+            let term = if let (Some(t), Some(a)) = (&query.title, &query.artist) {
+                format!("{t} {a}")
+            } else {
+                search_term(query)
+            };
+            Some(term)
+        };
+
+        debug!(provider = "deezer", query = ?q, "Sending search request");
+
+        let mut req = self.client.get(&url);
+        if let Some(q) = &q {
+            let limit = query.max_results.unwrap_or(10).to_string();
+            req = req.query(&[("q", q.as_str()), ("limit", &limit)]);
+        }
+
+        let response = req.send().await.map_err(net_err)?;
+
+        if !response.status().is_success() {
+            return Err(ProviderError::NetworkError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+
+        // ISRC lookup returns a single track object; wrap it
+        if query.isrc.is_some() {
+            let wrapped = format!("{{\"data\":[{body}]}}");
+            Self::parse_deezer("deezer", &wrapped)
+        } else {
+            Self::parse_deezer("deezer", &body)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deezer_name() {
+        let p = DeezerProvider::new();
+        assert_eq!(p.id(), "deezer");
+    }
+
+    #[test]
+    fn deezer_capabilities_music_search() {
+        let p = DeezerProvider::new();
+        assert!(p.capabilities().music_search);
+    }
+
+    #[test]
+    fn deezer_parse_valid_json() {
+        let json = r#"{
+            "data": [{
+                "id": 9876,
+                "title": "Get Lucky",
+                "artist": {"name": "Daft Punk"},
+                "album": {
+                    "title": "Random Access Memories",
+                    "cover_xl": "https://cdn.deezer.com/xl.jpg",
+                    "cover_medium": "https://cdn.deezer.com/med.jpg"
+                },
+                "duration": 248,
+                "isrc": "GBUM71300400",
+                "explicit_lyrics": false,
+                "rank": 850000
+            }]
+        }"#;
+        let results = DeezerProvider::parse_deezer("deezer", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Get Lucky"));
+        assert_eq!(results[0].artist.as_deref(), Some("Daft Punk"));
+        assert_eq!(results[0].isrc.as_deref(), Some("GBUM71300400"));
+        let duration = results[0]
+            .metadata
+            .get(DURATION_SECS)
+            .and_then(serde_json::Value::as_f64)
+            .unwrap();
+        assert!((duration - 248.0).abs() < 1e-3);
+        assert_eq!(results[0].cover_art.len(), 2);
+    }
+
+    #[test]
+    fn deezer_parse_empty_data() {
+        let json = r#"{"data": []}"#;
+        let results = DeezerProvider::parse_deezer("deezer", json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn deezer_parse_invalid_json_returns_err() {
+        let result = DeezerProvider::parse_deezer("deezer", "bad");
+        assert!(matches!(result, Err(ProviderError::Other(_))));
+    }
+}

--- a/crates/meedya-providers/src/providers/eidr.rs
+++ b/crates/meedya-providers/src/providers/eidr.rs
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// EIDR identifier provider.
+// Ported from MeedyaManager crates/mm-providers/src/identifiers/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{EIDR, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+/// Validate EIDR format: `10.5240/XXXX-XXXX-XXXX-XXXX-XXXX-C` (DOI-based).
+pub fn validate_eidr(eidr: &str) -> bool {
+    // Must start with the EIDR DOI prefix
+    eidr.starts_with("10.5240/") && eidr.len() > 10
+}
+
+/// Looks up EIDR (Entertainment Identifier Registry) titles for video content.
+///
+/// Endpoint: `https://id.eidr.org/EIDR/object/<DOI>`
+/// Auth:     Basic auth (EIDR registry account required)
+/// Limits:   10 RPM (paid API)
+pub struct EidrProvider {
+    client: Client,
+    base_url: String,
+    username: Option<String>,
+    password: Option<String>,
+}
+
+impl EidrProvider {
+    pub fn new(username: Option<String>, password: Option<String>) -> Self {
+        Self::with_base_url(username, password, "https://id.eidr.org")
+    }
+
+    pub fn with_base_url(
+        username: Option<String>,
+        password: Option<String>,
+        base_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            username,
+            password,
+        }
+    }
+
+    /// True if both username and password are present.
+    fn configured(&self) -> bool {
+        self.username.is_some() && self.password.is_some()
+    }
+
+    /// Parse an EIDR JSON response into a single `ProviderResult`.
+    fn parse_eidr_json(
+        provider_name: &str,
+        body: &str,
+    ) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct EidrRecord {
+            #[serde(rename = "ID")]
+            id: Option<String>,
+            #[serde(rename = "ResourceName")]
+            resource_name: Option<EidrLocalizedName>,
+            #[serde(rename = "ReleaseDate")]
+            release_date: Option<String>,
+            #[serde(rename = "ExtraObjectMetadata")]
+            extra: Option<EidrExtra>,
+        }
+
+        #[derive(Deserialize)]
+        struct EidrLocalizedName {
+            value: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct EidrExtra {
+            movie: Option<EidrMovie>,
+        }
+
+        #[derive(Deserialize)]
+        struct EidrMovie {
+            directors: Option<Vec<String>>,
+        }
+
+        let record: EidrRecord =
+            serde_json::from_str(body).map_err(|e| parse_err("EIDR response", e))?;
+
+        let year = record
+            .release_date
+            .as_deref()
+            .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+
+        let director = record
+            .extra
+            .as_ref()
+            .and_then(|e| e.movie.as_ref())
+            .and_then(|m| m.directors.as_deref())
+            .and_then(|d| d.first())
+            .cloned();
+
+        let mut result = ProviderResult::new(provider_name);
+        result.title = record.resource_name.and_then(|n| n.value);
+        result.artist = director; // Director for film
+        result.year = year;
+
+        if let Some(id) = record.id {
+            result
+                .metadata
+                .insert(PROVIDER_ID.into(), Value::String(id.clone()));
+            result.metadata.insert(EIDR.into(), Value::String(id));
+        }
+
+        Ok(vec![result])
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for EidrProvider {
+    fn id(&self) -> &str {
+        "eidr"
+    }
+
+    fn display_name(&self) -> &str {
+        "EIDR"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: false,
+            video_search: true,
+            podcast_search: false,
+            cover_art: false,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: true,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("eidr".into()));
+        }
+
+        let eidr = query.eidr.as_deref().ok_or_else(|| {
+            ProviderError::NotSupported("eidr: EIDR query requires an EIDR DOI".into())
+        })?;
+
+        if !validate_eidr(eidr) {
+            return Err(ProviderError::Other(format!(
+                "parse error: Invalid EIDR format: {eidr}"
+            )));
+        }
+
+        debug!(
+            provider = "eidr",
+            eidr = eidr,
+            "Sending EIDR lookup request"
+        );
+
+        let url = format!("{}/EIDR/object/{}", self.base_url, eidr);
+        let response = self
+            .client
+            .get(&url)
+            .basic_auth(self.username.as_deref().unwrap(), self.password.as_deref())
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            let s = response.status();
+            if s.as_u16() == 401 {
+                return Err(ProviderError::AuthenticationFailed {
+                    provider: "eidr".into(),
+                    reason: "Invalid EIDR credentials".into(),
+                });
+            }
+            return Err(ProviderError::NetworkError(format!("HTTP {s}")));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_eidr_json("eidr", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_eidr_valid() {
+        assert!(validate_eidr("10.5240/AEBE-0317-CE0D-4943-5916-E"));
+    }
+
+    #[test]
+    fn validate_eidr_wrong_prefix() {
+        assert!(!validate_eidr("10.1000/AEBE-0317-CE0D-4943-5916-E"));
+    }
+
+    #[test]
+    fn validate_eidr_too_short() {
+        assert!(!validate_eidr("10.5240/"));
+    }
+
+    #[test]
+    fn eidr_provider_name() {
+        assert_eq!(EidrProvider::new(None, None).id(), "eidr");
+    }
+
+    #[test]
+    fn eidr_provider_capabilities() {
+        let caps = EidrProvider::new(None, None).capabilities();
+        assert!(caps.identifier_lookup);
+        assert!(caps.video_search);
+    }
+
+    #[test]
+    fn eidr_provider_parse_json_valid() {
+        let json = r#"{
+            "ID": "10.5240/AEBE-0317-CE0D-4943-5916-E",
+            "ResourceName": {"value": "Inception"},
+            "ReleaseDate": "2010-07-16",
+            "ExtraObjectMetadata": {
+                "movie": {"directors": ["Christopher Nolan"]}
+            }
+        }"#;
+        let results = EidrProvider::parse_eidr_json("eidr", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Inception"));
+        assert_eq!(results[0].year, Some(2010));
+        assert_eq!(results[0].artist.as_deref(), Some("Christopher Nolan"));
+        // EIDR is now stored in metadata
+        assert_eq!(
+            results[0]
+                .metadata
+                .get(EIDR)
+                .and_then(serde_json::Value::as_str),
+            Some("10.5240/AEBE-0317-CE0D-4943-5916-E")
+        );
+    }
+}

--- a/crates/meedya-providers/src/providers/isrc.rs
+++ b/crates/meedya-providers/src/providers/isrc.rs
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// ISRC identifier provider (MusicBrainz recordings backend).
+// Ported from MeedyaManager crates/mm-providers/src/identifiers/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{DURATION_SECS, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+/// Validate ISRC format: 2 country + 3 registrant + 2 year + 5 designation = 12 chars.
+/// Accepts hyphens as separators (e.g. `GB-AYE-06-01498`).
+pub fn validate_isrc(isrc: &str) -> bool {
+    let normalised: String = isrc.chars().filter(|c| c.is_alphanumeric()).collect();
+    normalised.len() == 12
+        && normalised[..2].chars().all(|c| c.is_ascii_alphabetic())
+        && normalised[2..5].chars().all(|c| c.is_ascii_alphanumeric())
+        && normalised[5..7].chars().all(|c| c.is_ascii_digit())
+        && normalised[7..12].chars().all(|c| c.is_ascii_digit())
+}
+
+/// Looks up ISRC identifiers via MusicBrainz recording search.
+///
+/// Endpoint: `https://musicbrainz.org/ws/2/recording/?query=isrc:<ISRC>`
+/// Auth:     None (but User-Agent required)
+/// Limits:   30 RPM
+pub struct IsrcProvider {
+    client: Client,
+    base_url: String,
+    user_agent: String,
+}
+
+impl IsrcProvider {
+    pub fn new(user_agent: impl Into<String>) -> Self {
+        Self::with_base_url(user_agent, "https://musicbrainz.org")
+    }
+
+    pub fn with_base_url(user_agent: impl Into<String>, base_url: impl Into<String>) -> Self {
+        let user_agent = user_agent.into();
+        let client = Client::builder()
+            .user_agent(if user_agent.is_empty() {
+                "meedya-providers/0.1".to_string()
+            } else {
+                user_agent.clone()
+            })
+            .build()
+            .expect("reqwest ClientBuilder failed — TLS initialisation error");
+        Self {
+            client,
+            base_url: base_url.into(),
+            user_agent,
+        }
+    }
+
+    /// True if a User-Agent string is configured. Required by MusicBrainz API.
+    fn configured(&self) -> bool {
+        !self.user_agent.is_empty()
+    }
+
+    fn parse_recordings(
+        provider_name: &str,
+        body: &str,
+    ) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        struct MbResponse {
+            recordings: Vec<MbRecording>,
+        }
+        #[derive(Deserialize)]
+        struct MbRecording {
+            id: Option<String>,
+            title: Option<String>,
+            #[serde(rename = "artist-credit")]
+            artist_credit: Option<Vec<MbCredit>>,
+            releases: Option<Vec<MbRelease>>,
+            isrcs: Option<Vec<String>>,
+            length: Option<u64>,
+        }
+        #[derive(Deserialize)]
+        struct MbCredit {
+            artist: Option<MbArtist>,
+        }
+        #[derive(Deserialize)]
+        struct MbArtist {
+            name: Option<String>,
+        }
+        #[derive(Deserialize)]
+        struct MbRelease {
+            title: Option<String>,
+            date: Option<String>,
+        }
+
+        let resp: MbResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("ISRC/MusicBrainz response", e))?;
+
+        let results = resp
+            .recordings
+            .into_iter()
+            .map(|rec| {
+                let artist = rec.artist_credit.as_deref().map(|credits| {
+                    credits
+                        .iter()
+                        .filter_map(|c| c.artist.as_ref()?.name.as_deref())
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                });
+                let first_release = rec.releases.as_deref().and_then(|r| r.first());
+                let album = first_release.and_then(|r| r.title.clone());
+                let year = first_release
+                    .and_then(|r| r.date.as_deref())
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = rec.title;
+                result.artist = artist;
+                result.album = album;
+                result.year = year;
+                result.isrc = rec.isrcs.and_then(|v| v.into_iter().next());
+
+                if let Some(id) = rec.id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id));
+                }
+                if let Some(length_ms) = rec.length {
+                    let secs = length_ms as f64 / 1000.0;
+                    if let Some(num) = serde_json::Number::from_f64(secs) {
+                        result
+                            .metadata
+                            .insert(DURATION_SECS.into(), Value::Number(num));
+                    }
+                }
+
+                result
+            })
+            .collect();
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for IsrcProvider {
+    fn id(&self) -> &str {
+        "isrc"
+    }
+
+    fn display_name(&self) -> &str {
+        "ISRC (via MusicBrainz)"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: true,
+            video_search: false,
+            podcast_search: false,
+            cover_art: false,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: true,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("isrc".into()));
+        }
+
+        let isrc = query.isrc.as_deref().ok_or_else(|| {
+            ProviderError::NotSupported("isrc: ISRC query requires an ISRC code".into())
+        })?;
+
+        if !validate_isrc(isrc) {
+            return Err(ProviderError::Other(format!(
+                "parse error: Invalid ISRC format: {isrc}"
+            )));
+        }
+
+        debug!(
+            provider = "isrc",
+            isrc = isrc,
+            "Sending ISRC lookup request"
+        );
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let url = format!("{}/ws/2/recording/", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .header("Accept", "application/json")
+            .query(&[
+                ("query", &format!("isrc:{isrc}")),
+                ("limit", &limit),
+                ("fmt", &"json".to_owned()),
+            ])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            let s = response.status();
+            if s.as_u16() == 503 {
+                return Err(ProviderError::RateLimited("isrc".into()));
+            }
+            return Err(ProviderError::NetworkError(format!("HTTP {s}")));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_recordings("isrc", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_isrc_valid_standard() {
+        assert!(validate_isrc("GBAYE0601498")); // 12 chars, no hyphens
+    }
+
+    #[test]
+    fn validate_isrc_valid_with_hyphens() {
+        assert!(validate_isrc("GB-AYE-06-01498"));
+    }
+
+    #[test]
+    fn validate_isrc_too_short() {
+        assert!(!validate_isrc("GBAYE060149")); // 11 chars
+    }
+
+    #[test]
+    fn validate_isrc_too_long() {
+        assert!(!validate_isrc("GBAYE06014980")); // 13 chars
+    }
+
+    #[test]
+    fn validate_isrc_invalid_country_code() {
+        // Country must be 2 letters; digits in first 2 positions → invalid
+        assert!(!validate_isrc("12AYE0601498"));
+    }
+
+    #[test]
+    fn isrc_provider_name() {
+        assert_eq!(IsrcProvider::new("App/1.0").id(), "isrc");
+    }
+
+    #[test]
+    fn isrc_provider_capabilities() {
+        let caps = IsrcProvider::new("App/1.0").capabilities();
+        assert!(caps.identifier_lookup);
+        assert!(caps.music_search);
+        assert!(!caps.cover_art);
+    }
+
+    #[test]
+    fn isrc_provider_parse_recordings_valid() {
+        let json = r#"{
+            "recordings": [{
+                "id": "mb-rec-1",
+                "title": "Comfortably Numb",
+                "artist-credit": [{"artist": {"name": "Pink Floyd"}}],
+                "releases": [{"title": "The Wall", "date": "1979-11-30"}],
+                "isrcs": ["GBAYE7900498"],
+                "length": 382000
+            }]
+        }"#;
+        let results = IsrcProvider::parse_recordings("isrc", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Comfortably Numb"));
+        assert_eq!(results[0].isrc.as_deref(), Some("GBAYE7900498"));
+        assert_eq!(results[0].artist.as_deref(), Some("Pink Floyd"));
+    }
+
+    #[test]
+    fn isrc_provider_parse_invalid_json_returns_err() {
+        assert!(matches!(
+            IsrcProvider::parse_recordings("isrc", "bad"),
+            Err(ProviderError::Other(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn isrc_provider_search_without_isrc_returns_not_supported() {
+        let p = IsrcProvider::new("App/1.0");
+        let q = SearchQuery {
+            max_results: Some(5),
+            ..Default::default()
+        };
+        assert!(matches!(
+            p.search(&q).await,
+            Err(ProviderError::NotSupported(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn isrc_provider_search_invalid_isrc_returns_parse_err() {
+        let p = IsrcProvider::new("App/1.0");
+        let q = SearchQuery {
+            isrc: Some("BAD".into()),
+            max_results: Some(5),
+            ..Default::default()
+        };
+        assert!(matches!(p.search(&q).await, Err(ProviderError::Other(_))));
+    }
+}

--- a/crates/meedya-providers/src/providers/iswc.rs
+++ b/crates/meedya-providers/src/providers/iswc.rs
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// ISWC identifier provider (MusicBrainz works backend).
+// Ported from MeedyaManager crates/mm-providers/src/identifiers/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{ISWC, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+/// Validate ISWC format: `T-123456789-C` (T + 9 digits + check digit).
+/// Accepts the format with or without hyphens.
+pub fn validate_iswc(iswc: &str) -> bool {
+    let normalised: String = iswc
+        .to_uppercase()
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect();
+    // Must be exactly 11 chars: T + 9 digits + 1 check digit
+    normalised.len() == 11
+        && normalised.starts_with('T')
+        && normalised[1..].chars().all(|c| c.is_ascii_digit())
+}
+
+/// Looks up ISWC identifiers via MusicBrainz works API.
+///
+/// Endpoint: `https://musicbrainz.org/ws/2/work/?query=iswc:<ISWC>`
+/// Auth:     None (but User-Agent required)
+/// Limits:   50 RPM
+pub struct IswcProvider {
+    client: Client,
+    base_url: String,
+    user_agent: String,
+}
+
+impl IswcProvider {
+    pub fn new(user_agent: impl Into<String>) -> Self {
+        Self::with_base_url(user_agent, "https://musicbrainz.org")
+    }
+
+    pub fn with_base_url(user_agent: impl Into<String>, base_url: impl Into<String>) -> Self {
+        let user_agent = user_agent.into();
+        let client = Client::builder()
+            .user_agent(if user_agent.is_empty() {
+                "meedya-providers/0.1".to_string()
+            } else {
+                user_agent.clone()
+            })
+            .build()
+            .expect("reqwest ClientBuilder failed — TLS initialisation error");
+        Self {
+            client,
+            base_url: base_url.into(),
+            user_agent,
+        }
+    }
+
+    fn configured(&self) -> bool {
+        !self.user_agent.is_empty()
+    }
+
+    fn parse_works(provider_name: &str, body: &str) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        struct MbWorksResponse {
+            works: Vec<MbWork>,
+        }
+        #[derive(Deserialize)]
+        struct MbWork {
+            id: Option<String>,
+            title: Option<String>,
+            iswcs: Option<Vec<String>>,
+            relations: Option<Vec<MbRelation>>,
+        }
+        #[derive(Deserialize)]
+        struct MbRelation {
+            #[serde(rename = "type")]
+            rel_type: Option<String>,
+            artist: Option<MbRelArtist>,
+        }
+        #[derive(Deserialize)]
+        struct MbRelArtist {
+            name: Option<String>,
+        }
+
+        let resp: MbWorksResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("ISWC/MusicBrainz response", e))?;
+
+        let results = resp
+            .works
+            .into_iter()
+            .map(|work| {
+                // Find the composer from relations
+                let composer = work.relations.as_deref().and_then(|rels| {
+                    rels.iter()
+                        .find(|r| r.rel_type.as_deref() == Some("composer"))
+                        .and_then(|r| r.artist.as_ref()?.name.clone())
+                });
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = work.title;
+                result.artist = composer;
+
+                if let Some(id) = work.id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id));
+                }
+                if let Some(iswc) = work.iswcs.and_then(|v| v.into_iter().next()) {
+                    result.metadata.insert(ISWC.into(), Value::String(iswc));
+                }
+                result
+            })
+            .collect();
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for IswcProvider {
+    fn id(&self) -> &str {
+        "iswc"
+    }
+
+    fn display_name(&self) -> &str {
+        "ISWC (via MusicBrainz)"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: true,
+            video_search: false,
+            podcast_search: false,
+            cover_art: false,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: true,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("iswc".into()));
+        }
+
+        let iswc = query.iswc.as_deref().ok_or_else(|| {
+            ProviderError::NotSupported("iswc: ISWC query requires an ISWC code".into())
+        })?;
+
+        if !validate_iswc(iswc) {
+            return Err(ProviderError::Other(format!(
+                "parse error: Invalid ISWC format: {iswc}"
+            )));
+        }
+
+        debug!(
+            provider = "iswc",
+            iswc = iswc,
+            "Sending ISWC lookup request"
+        );
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let url = format!("{}/ws/2/work/", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .header("Accept", "application/json")
+            .query(&[
+                ("query", &format!("iswc:{iswc}")),
+                ("limit", &limit),
+                ("fmt", &"json".to_owned()),
+            ])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            let s = response.status();
+            if s.as_u16() == 503 {
+                return Err(ProviderError::RateLimited("iswc".into()));
+            }
+            return Err(ProviderError::NetworkError(format!("HTTP {s}")));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_works("iswc", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_iswc_valid_standard() {
+        assert!(validate_iswc("T0345246801")); // T + 10 digits
+    }
+
+    #[test]
+    fn validate_iswc_valid_with_hyphens() {
+        assert!(validate_iswc("T-034524680-1"));
+    }
+
+    #[test]
+    fn validate_iswc_wrong_prefix() {
+        assert!(!validate_iswc("X0345246801")); // Must start with T
+    }
+
+    #[test]
+    fn validate_iswc_too_short() {
+        assert!(!validate_iswc("T034524680")); // 10 chars (T + 9 digits) — need 11
+    }
+
+    #[test]
+    fn iswc_provider_name() {
+        assert_eq!(IswcProvider::new("App/1.0").id(), "iswc");
+    }
+
+    #[test]
+    fn iswc_provider_capabilities() {
+        let caps = IswcProvider::new("App/1.0").capabilities();
+        assert!(caps.identifier_lookup);
+        assert!(caps.music_search);
+    }
+
+    #[test]
+    fn iswc_provider_parse_works_valid() {
+        let json = r#"{
+            "works": [{
+                "id": "mb-work-1",
+                "title": "Bohemian Rhapsody",
+                "iswcs": ["T0345246801"],
+                "relations": [{
+                    "type": "composer",
+                    "artist": {"name": "Freddie Mercury"}
+                }]
+            }]
+        }"#;
+        let results = IswcProvider::parse_works("iswc", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Bohemian Rhapsody"));
+        assert_eq!(results[0].artist.as_deref(), Some("Freddie Mercury"));
+        assert_eq!(
+            results[0]
+                .metadata
+                .get(ISWC)
+                .and_then(serde_json::Value::as_str),
+            Some("T0345246801")
+        );
+    }
+
+    #[test]
+    fn iswc_provider_parse_invalid_json_returns_err() {
+        assert!(matches!(
+            IswcProvider::parse_works("iswc", "bad"),
+            Err(ProviderError::Other(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn iswc_provider_search_without_iswc_returns_not_supported() {
+        let p = IswcProvider::new("App/1.0");
+        let q = SearchQuery {
+            max_results: Some(5),
+            ..Default::default()
+        };
+        assert!(matches!(
+            p.search(&q).await,
+            Err(ProviderError::NotSupported(_))
+        ));
+    }
+}

--- a/crates/meedya-providers/src/providers/itunes_store.rs
+++ b/crates/meedya-providers/src/providers/itunes_store.rs
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// iTunes Store metadata provider (iTunes Search API — tvShow entity).
+// Ported from MeedyaManager crates/mm-providers/src/video/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+//
+// Uses the same iTunes Search API as AppleTvProvider but targets the `tvShow`
+// media type / `tvSeason` entity. Re-implements the parse helper inline so each
+// provider feature can be toggled independently without cross-module deps.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{CONTENT_ADVISORY, DURATION_SECS, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+fn insert_duration(result: &mut ProviderResult, secs: f64) {
+    if let Some(num) = serde_json::Number::from_f64(secs) {
+        result
+            .metadata
+            .insert(DURATION_SECS.into(), Value::Number(num));
+    }
+}
+
+/// Searches the iTunes Store for purchased/available movies and TV shows.
+///
+/// Auth: None; Limits: 20 RPM
+pub struct ItunesStoreProvider {
+    client: Client,
+    base_url: String,
+    enabled: bool,
+    country: String,
+}
+
+impl ItunesStoreProvider {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self::with_base_url(country, "https://itunes.apple.com")
+    }
+
+    pub fn with_base_url(country: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            enabled: true,
+            country: country.into(),
+        }
+    }
+
+    pub(crate) fn parse(
+        provider_name: &str,
+        body: &str,
+    ) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesVideoResponse {
+            results: Vec<ItunesVideoResult>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ItunesVideoResult {
+            track_id: Option<u64>,
+            track_name: Option<String>,
+            artist_name: Option<String>,
+            collection_name: Option<String>,
+            artwork_url100: Option<String>,
+            release_date: Option<String>,
+            track_time_millis: Option<u64>,
+            primary_genre_name: Option<String>,
+            content_advisory_rating: Option<String>,
+        }
+
+        let resp: ItunesVideoResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("iTunes Store response", e))?;
+
+        let results = resp
+            .results
+            .into_iter()
+            .map(|r| {
+                let year = r
+                    .release_date
+                    .as_deref()
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+                let cover_art = r
+                    .artwork_url100
+                    .as_deref()
+                    .map(|url| {
+                        let hires = url.replace("100x100", "600x600");
+                        vec![
+                            CoverArtInfo {
+                                url: hires,
+                                width: Some(600),
+                                height: Some(600),
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                            CoverArtInfo {
+                                url: url.to_owned(),
+                                width: Some(100),
+                                height: Some(100),
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                        ]
+                    })
+                    .unwrap_or_default();
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = r.track_name;
+                result.artist = r.artist_name;
+                result.album = r.collection_name;
+                result.year = year;
+                result.genre = r.primary_genre_name;
+                result.cover_art = cover_art;
+
+                if let Some(id) = r.track_id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id.to_string()));
+                }
+                if let Some(ms) = r.track_time_millis {
+                    insert_duration(&mut result, ms as f64 / 1000.0);
+                }
+                if let Some(advisory) = r.content_advisory_rating {
+                    result
+                        .metadata
+                        .insert(CONTENT_ADVISORY.into(), Value::String(advisory));
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+impl Default for ItunesStoreProvider {
+    fn default() -> Self {
+        Self::new("US")
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for ItunesStoreProvider {
+    fn id(&self) -> &str {
+        "itunes_store"
+    }
+
+    fn display_name(&self) -> &str {
+        "iTunes Store"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: false,
+            video_search: true,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.enabled {
+            return Err(ProviderError::NotConfigured("itunes_store".into()));
+        }
+        let fallback = format!(
+            "{} {}",
+            query.title.as_deref().unwrap_or(""),
+            query.artist.as_deref().unwrap_or("")
+        );
+        let term: &str = query.title.as_deref().unwrap_or(fallback.trim());
+        debug!(
+            provider = "itunes_store",
+            term = term,
+            "Sending iTunes TV search request"
+        );
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let url = format!("{}/search", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("term", term),
+                ("media", "tvShow"),
+                ("entity", "tvSeason"),
+                ("country", &self.country),
+                ("limit", &limit),
+            ])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            return Err(ProviderError::NetworkError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse("itunes_store", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn itunes_store_name() {
+        assert_eq!(ItunesStoreProvider::new("US").id(), "itunes_store");
+    }
+
+    #[test]
+    fn itunes_store_capabilities_video_type() {
+        assert!(ItunesStoreProvider::default().capabilities().video_search);
+    }
+
+    #[test]
+    fn itunes_store_parse_valid_json() {
+        let json =
+            r#"{"results": [{"trackId": 9999, "trackName": "Breaking Bad", "artistName": "AMC"}]}"#;
+        let results = ItunesStoreProvider::parse("itunes_store", json).unwrap();
+        assert_eq!(results[0].title.as_deref(), Some("Breaking Bad"));
+    }
+}

--- a/crates/meedya-providers/src/providers/mod.rs
+++ b/crates/meedya-providers/src/providers/mod.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Concrete provider implementations, each gated by its own feature flag.
+//
+// Each provider lives in its own file (`<name>.rs`) and is conditionally
+// compiled via `#[cfg(feature = "provider-<name>")]`. Apps opt in only to
+// the providers they need; downstream binary size and dependency surface
+// scales with the chosen feature set.
+//
+// Ported from MeedyaManager `crates/mm-providers/src/{music,video,
+// identifiers,podcasts}/mod.rs` under MeedyaSuite-core#12 / MeedyaManager#136.
+
+#[cfg(feature = "provider-musicbrainz")]
+pub mod musicbrainz;
+#[cfg(feature = "provider-musicbrainz")]
+pub use musicbrainz::MusicBrainzProvider;
+
+#[cfg(feature = "provider-spotify")]
+pub mod spotify;
+#[cfg(feature = "provider-spotify")]
+pub use spotify::SpotifyProvider;
+
+#[cfg(feature = "provider-apple-music")]
+pub mod apple_music;
+#[cfg(feature = "provider-apple-music")]
+pub use apple_music::AppleMusicProvider;
+
+#[cfg(feature = "provider-deezer")]
+pub mod deezer;
+#[cfg(feature = "provider-deezer")]
+pub use deezer::DeezerProvider;
+
+#[cfg(feature = "provider-tmdb")]
+pub mod tmdb;
+#[cfg(feature = "provider-tmdb")]
+pub use tmdb::TmdbProvider;
+
+#[cfg(feature = "provider-thetvdb")]
+pub mod thetvdb;
+#[cfg(feature = "provider-thetvdb")]
+pub use thetvdb::TheTvdbProvider;
+
+#[cfg(feature = "provider-omdb")]
+pub mod omdb;
+#[cfg(feature = "provider-omdb")]
+pub use omdb::OmdbProvider;
+
+#[cfg(feature = "provider-apple-tv")]
+pub mod apple_tv;
+#[cfg(feature = "provider-apple-tv")]
+pub use apple_tv::AppleTvProvider;
+
+#[cfg(feature = "provider-itunes-store")]
+pub mod itunes_store;
+#[cfg(feature = "provider-itunes-store")]
+pub use itunes_store::ItunesStoreProvider;
+
+#[cfg(feature = "provider-apple-podcasts")]
+pub mod apple_podcasts;
+#[cfg(feature = "provider-apple-podcasts")]
+pub use apple_podcasts::ApplePodcastsProvider;
+
+#[cfg(feature = "provider-isrc")]
+pub mod isrc;
+#[cfg(feature = "provider-isrc")]
+pub use isrc::IsrcProvider;
+
+#[cfg(feature = "provider-eidr")]
+pub mod eidr;
+#[cfg(feature = "provider-eidr")]
+pub use eidr::EidrProvider;
+
+#[cfg(feature = "provider-iswc")]
+pub mod iswc;
+#[cfg(feature = "provider-iswc")]
+pub use iswc::IswcProvider;

--- a/crates/meedya-providers/src/providers/musicbrainz.rs
+++ b/crates/meedya-providers/src/providers/musicbrainz.rs
@@ -1,0 +1,332 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// MusicBrainz metadata provider.
+// Ported from MeedyaManager crates/mm-providers/src/music/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{DURATION_SECS, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{ProviderResult, SearchQuery};
+
+/// Build a `ProviderError::NetworkError` from a `reqwest::Error`.
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+/// Build a parse-style `ProviderError::Other`.
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+/// Resolve a free-text search term from `SearchQuery` (title + artist).
+fn search_term(query: &SearchQuery) -> String {
+    let combined = format!(
+        "{} {}",
+        query.title.as_deref().unwrap_or(""),
+        query.artist.as_deref().unwrap_or("")
+    );
+    combined.trim().to_owned()
+}
+
+/// Insert duration (seconds) into result metadata using the conventional key.
+fn insert_duration(result: &mut ProviderResult, secs: f64) {
+    if let Some(num) = serde_json::Number::from_f64(secs) {
+        result
+            .metadata
+            .insert(DURATION_SECS.into(), Value::Number(num));
+    }
+}
+
+/// Searches the MusicBrainz open database.
+///
+/// Endpoint: `https://musicbrainz.org/ws/2/recording/`
+/// Auth:     None required (but a User-Agent string is required)
+/// Limits:   50 RPM (free tier)
+pub struct MusicBrainzProvider {
+    client: Client,
+    base_url: String,
+    /// Required by MusicBrainz API: identifies the application making requests.
+    #[allow(dead_code)]
+    user_agent: String,
+}
+
+impl MusicBrainzProvider {
+    /// Create a provider with the standard MusicBrainz endpoint.
+    pub fn new(user_agent: impl Into<String>) -> Self {
+        Self::with_base_url(user_agent, "https://musicbrainz.org")
+    }
+
+    /// Create a provider with a custom base URL (useful for test mocking).
+    pub fn with_base_url(user_agent: impl Into<String>, base_url: impl Into<String>) -> Self {
+        let user_agent = user_agent.into();
+        let client = Client::builder()
+            .user_agent(if user_agent.is_empty() {
+                "meedya-providers/0.1".to_string()
+            } else {
+                user_agent.clone()
+            })
+            .build()
+            .expect("reqwest ClientBuilder failed — TLS initialisation error");
+        Self {
+            client,
+            base_url: base_url.into(),
+            user_agent,
+        }
+    }
+
+    /// True when a User-Agent string is configured. Required by MusicBrainz API.
+    fn configured(&self) -> bool {
+        !self.user_agent.is_empty()
+    }
+
+    /// Parse a MusicBrainz recording search response into `ProviderResult`s.
+    fn parse_recordings(
+        provider_name: &str,
+        body: &str,
+    ) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        struct MbResponse {
+            recordings: Vec<MbRecording>,
+        }
+
+        #[derive(Deserialize)]
+        struct MbRecording {
+            id: Option<String>,
+            title: Option<String>,
+            #[serde(rename = "artist-credit")]
+            artist_credit: Option<Vec<MbArtistCredit>>,
+            releases: Option<Vec<MbRelease>>,
+            isrcs: Option<Vec<String>>,
+            length: Option<u64>,
+            score: Option<u32>,
+        }
+
+        #[derive(Deserialize)]
+        struct MbArtistCredit {
+            artist: Option<MbArtist>,
+        }
+
+        #[derive(Deserialize)]
+        struct MbArtist {
+            name: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct MbRelease {
+            title: Option<String>,
+            date: Option<String>,
+            #[serde(rename = "track-count")]
+            #[allow(dead_code)]
+            track_count: Option<u32>,
+        }
+
+        let resp: MbResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("MusicBrainz response", e))?;
+
+        let results = resp
+            .recordings
+            .into_iter()
+            .map(|rec| {
+                // Combine artist-credit names
+                let artist = rec.artist_credit.as_deref().map(|credits| {
+                    credits
+                        .iter()
+                        .filter_map(|c| c.artist.as_ref()?.name.as_deref())
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                });
+
+                // Use the first release for album/year info
+                let first_release = rec.releases.as_deref().and_then(|r| r.first());
+                let album = first_release.and_then(|r| r.title.clone());
+                let year = first_release
+                    .and_then(|r| r.date.as_deref())
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+
+                // MusicBrainz score is 0–100; normalise to [0.0, 1.0]
+                let score = f64::from(rec.score.unwrap_or(0)) / 100.0;
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = rec.title;
+                result.artist = artist;
+                result.album = album;
+                result.year = year;
+                result.isrc = rec.isrcs.and_then(|v| v.into_iter().next());
+                result.score = score;
+
+                if let Some(id) = rec.id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id));
+                }
+                if let Some(ms) = rec.length {
+                    insert_duration(&mut result, ms as f64 / 1000.0);
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for MusicBrainzProvider {
+    fn id(&self) -> &str {
+        "musicbrainz"
+    }
+
+    fn display_name(&self) -> &str {
+        "MusicBrainz"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: true,
+            video_search: false,
+            podcast_search: false,
+            // Cover art comes via the Cover Art Archive (a separate provider).
+            cover_art: false,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("musicbrainz".into()));
+        }
+
+        // Build query string: ISRC takes priority over free-text
+        let lucene_query = if let Some(isrc) = &query.isrc {
+            format!("isrc:{isrc}")
+        } else {
+            let mut parts = Vec::new();
+            if let Some(title) = &query.title {
+                parts.push(format!("recording:{}", title.replace('"', "")));
+            }
+            if let Some(artist) = &query.artist {
+                parts.push(format!("artistname:{}", artist.replace('"', "")));
+            }
+            if parts.is_empty() {
+                search_term(query)
+            } else {
+                parts.join(" AND ")
+            }
+        };
+
+        let url = format!("{}/ws/2/recording/", self.base_url);
+        debug!(
+            provider = "musicbrainz",
+            query = &lucene_query,
+            "Sending search request"
+        );
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let response = self
+            .client
+            .get(&url)
+            .header("Accept", "application/json")
+            .query(&[
+                ("query", &lucene_query as &str),
+                ("limit", &limit),
+                ("fmt", "json"),
+            ])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            if status.as_u16() == 503 {
+                return Err(ProviderError::RateLimited("musicbrainz".into()));
+            }
+            return Err(ProviderError::NetworkError(format!("HTTP {status}")));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_recordings("musicbrainz", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mb_name() {
+        let p = MusicBrainzProvider::new("TestApp/1.0");
+        assert_eq!(p.id(), "musicbrainz");
+    }
+
+    #[test]
+    fn mb_capabilities_music_type() {
+        let p = MusicBrainzProvider::new("TestApp/1.0");
+        assert!(p.capabilities().music_search);
+        assert!(!p.capabilities().video_search);
+    }
+
+    #[test]
+    fn mb_capabilities_no_cover_art() {
+        let p = MusicBrainzProvider::new("TestApp/1.0");
+        // MusicBrainz exposes cover art via the Cover Art Archive (a separate provider).
+        assert!(!p.capabilities().cover_art);
+    }
+
+    #[test]
+    fn mb_parse_recordings_valid_json() {
+        let json = r#"{
+            "recordings": [{
+                "id": "abc123",
+                "title": "Comfortably Numb",
+                "artist-credit": [{"artist": {"name": "Pink Floyd"}}],
+                "releases": [{"title": "The Wall", "date": "1979-11-30"}],
+                "isrcs": ["GBAYE7900498"],
+                "length": 382000,
+                "score": 100
+            }]
+        }"#;
+        let results = MusicBrainzProvider::parse_recordings("musicbrainz", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Comfortably Numb"));
+        assert_eq!(results[0].artist.as_deref(), Some("Pink Floyd"));
+        assert_eq!(results[0].album.as_deref(), Some("The Wall"));
+        assert_eq!(results[0].year, Some(1979));
+        assert_eq!(results[0].isrc.as_deref(), Some("GBAYE7900498"));
+        assert!((results[0].score - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mb_parse_recordings_empty_list() {
+        let json = r#"{"recordings": []}"#;
+        let results = MusicBrainzProvider::parse_recordings("musicbrainz", json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn mb_parse_recordings_invalid_json_returns_err() {
+        let result = MusicBrainzProvider::parse_recordings("musicbrainz", "not json");
+        assert!(matches!(result, Err(ProviderError::Other(_))));
+    }
+
+    #[test]
+    fn mb_parse_duration_conversion_ms_to_secs() {
+        let json = r#"{"recordings": [{"id": "x", "length": 240000, "score": 50}]}"#;
+        let results = MusicBrainzProvider::parse_recordings("musicbrainz", json).unwrap();
+        let duration = results[0]
+            .metadata
+            .get(DURATION_SECS)
+            .and_then(serde_json::Value::as_f64)
+            .unwrap();
+        assert!((duration - 240.0).abs() < 1e-3);
+    }
+}

--- a/crates/meedya-providers/src/providers/omdb.rs
+++ b/crates/meedya-providers/src/providers/omdb.rs
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// OMDb (Open Movie Database) provider.
+// Ported from MeedyaManager crates/mm-providers/src/video/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::PROVIDER_ID;
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+/// Searches the OMDb API, which provides IMDb-sourced film/TV metadata.
+///
+/// Endpoint: `https://www.omdbapi.com/`
+/// Auth:     API key (`apikey` query param; free tier = 1000 req/day)
+/// Limits:   10 RPM (free tier)
+pub struct OmdbProvider {
+    client: Client,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl OmdbProvider {
+    pub fn new(api_key: Option<String>) -> Self {
+        Self::with_base_url(api_key, "https://www.omdbapi.com")
+    }
+
+    pub fn with_base_url(api_key: Option<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            api_key,
+        }
+    }
+
+    fn configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    fn parse_search(provider_name: &str, body: &str) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct OmdbSearchResponse {
+            search: Option<Vec<OmdbSearchResult>>,
+            #[serde(rename = "Error")]
+            error: Option<String>,
+        }
+        #[derive(Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct OmdbSearchResult {
+            #[serde(rename = "imdbID")]
+            imdb_id: Option<String>,
+            title: Option<String>,
+            year: Option<String>,
+            poster: Option<String>,
+            #[serde(rename = "Type")]
+            media_type: Option<String>,
+        }
+
+        let resp: OmdbSearchResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("OMDb response", e))?;
+
+        if let Some(err) = resp.error {
+            return Err(ProviderError::Other(format!(
+                "parse error: OMDb error: {err}"
+            )));
+        }
+
+        let items = resp.search.unwrap_or_default();
+        let results = items
+            .into_iter()
+            .map(|r| {
+                let year = r
+                    .year
+                    .as_deref()
+                    .and_then(|y| y[..4.min(y.len())].parse::<u32>().ok());
+                let cover_art = r
+                    .poster
+                    .as_deref()
+                    .filter(|p| *p != "N/A" && !p.is_empty())
+                    .map(|p| {
+                        vec![CoverArtInfo {
+                            url: p.to_owned(),
+                            width: None,
+                            height: None,
+                            mime_type: Some("image/jpeg".into()),
+                        }]
+                    })
+                    .unwrap_or_default();
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = r.title;
+                result.year = year;
+                result.cover_art = cover_art;
+
+                if let Some(id) = r.imdb_id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id));
+                }
+                if let Some(t) = &r.media_type {
+                    result
+                        .metadata
+                        .insert("media_type".into(), Value::String(t.clone()));
+                }
+
+                result
+            })
+            .collect();
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for OmdbProvider {
+    fn id(&self) -> &str {
+        "omdb"
+    }
+
+    fn display_name(&self) -> &str {
+        "OMDb / IMDb"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: false,
+            video_search: true,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("omdb".into()));
+        }
+        let key = self.api_key.as_deref().unwrap();
+        let fallback = format!(
+            "{} {}",
+            query.title.as_deref().unwrap_or(""),
+            query.artist.as_deref().unwrap_or("")
+        );
+        let title: &str = query.title.as_deref().unwrap_or(fallback.trim());
+
+        debug!(provider = "omdb", title = title, "Sending search request");
+
+        let mut params = vec![
+            ("s", title.to_owned()),
+            ("apikey", key.to_owned()),
+            ("type", "movie".to_owned()), // Default to movies; could be configurable
+        ];
+        if let Some(y) = query.year {
+            params.push(("y", y.to_string()));
+        }
+
+        let response = self
+            .client
+            .get(&self.base_url)
+            .query(&params)
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            return Err(ProviderError::NetworkError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_search("omdb", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn omdb_name() {
+        assert_eq!(OmdbProvider::new(Some("key".into())).id(), "omdb");
+    }
+
+    #[test]
+    fn omdb_parse_search_valid_json() {
+        let json = r#"{
+            "Search": [{
+                "Title": "Interstellar",
+                "Year": "2014",
+                "imdbID": "tt0816692",
+                "Type": "movie",
+                "Poster": "https://m.media-amazon.com/images/M/poster.jpg"
+            }],
+            "totalResults": "1",
+            "Response": "True"
+        }"#;
+        let results = OmdbProvider::parse_search("omdb", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Interstellar"));
+        assert_eq!(results[0].year, Some(2014));
+        assert_eq!(
+            results[0]
+                .metadata
+                .get(PROVIDER_ID)
+                .and_then(serde_json::Value::as_str),
+            Some("tt0816692")
+        );
+        assert!(!results[0].cover_art.is_empty());
+    }
+
+    #[test]
+    fn omdb_parse_error_response_returns_err() {
+        let json = r#"{"Response": "False", "Error": "Movie not found!"}"#;
+        let result = OmdbProvider::parse_search("omdb", json);
+        assert!(matches!(result, Err(ProviderError::Other(_))));
+    }
+
+    #[test]
+    fn omdb_parse_na_poster_produces_no_cover_art() {
+        let json = r#"{
+            "Search": [{"Title": "X", "Year": "2020", "imdbID": "tt0", "Type": "movie", "Poster": "N/A"}]
+        }"#;
+        let results = OmdbProvider::parse_search("omdb", json).unwrap();
+        assert!(results[0].cover_art.is_empty());
+    }
+
+    #[test]
+    fn omdb_parse_invalid_json_returns_err() {
+        assert!(matches!(
+            OmdbProvider::parse_search("omdb", "bad"),
+            Err(ProviderError::Other(_))
+        ));
+    }
+}

--- a/crates/meedya-providers/src/providers/spotify.rs
+++ b/crates/meedya-providers/src/providers/spotify.rs
@@ -1,0 +1,400 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// Spotify provider (Client Credentials OAuth2).
+// Ported from MeedyaManager crates/mm-providers/src/music/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::{CONTENT_ADVISORY, DURATION_SECS, PROVIDER_ID};
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+fn search_term(query: &SearchQuery) -> String {
+    let combined = format!(
+        "{} {}",
+        query.title.as_deref().unwrap_or(""),
+        query.artist.as_deref().unwrap_or("")
+    );
+    combined.trim().to_owned()
+}
+
+fn insert_duration(result: &mut ProviderResult, secs: f64) {
+    if let Some(num) = serde_json::Number::from_f64(secs) {
+        result
+            .metadata
+            .insert(DURATION_SECS.into(), Value::Number(num));
+    }
+}
+
+/// Searches the Spotify Web API using Client Credentials OAuth2.
+///
+/// Endpoint: `https://api.spotify.com/v1/search`
+/// Auth:     OAuth2 client-credentials (`client_id` + `client_secret`)
+/// Limits:   100 RPM (standard tier)
+pub struct SpotifyProvider {
+    client: Client,
+    base_url: String,
+    client_id: Option<String>,
+    client_secret: Option<String>,
+}
+
+impl SpotifyProvider {
+    /// Create a Spotify provider. `client_id` and `client_secret` are optional;
+    /// the provider is disabled if either is `None`.
+    pub fn new(client_id: Option<String>, client_secret: Option<String>) -> Self {
+        Self::with_base_url(client_id, client_secret, "https://api.spotify.com")
+    }
+
+    /// Create a Spotify provider with a custom base URL (for test mocking).
+    pub fn with_base_url(
+        client_id: Option<String>,
+        client_secret: Option<String>,
+        base_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            client_id,
+            client_secret,
+        }
+    }
+
+    fn configured(&self) -> bool {
+        self.client_id.is_some() && self.client_secret.is_some()
+    }
+
+    /// Obtain an access token using Client Credentials OAuth2.
+    async fn get_access_token(&self) -> Result<String, ProviderError> {
+        let id = self
+            .client_id
+            .as_deref()
+            .ok_or_else(|| ProviderError::AuthenticationFailed {
+                provider: "spotify".into(),
+                reason: "No client_id".into(),
+            })?;
+        let secret =
+            self.client_secret
+                .as_deref()
+                .ok_or_else(|| ProviderError::AuthenticationFailed {
+                    provider: "spotify".into(),
+                    reason: "No client_secret".into(),
+                })?;
+
+        let resp = self
+            .client
+            .post("https://accounts.spotify.com/api/token")
+            .basic_auth(id, Some(secret))
+            .form(&[("grant_type", "client_credentials")])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !resp.status().is_success() {
+            return Err(ProviderError::AuthenticationFailed {
+                provider: "spotify".into(),
+                reason: format!("Token request failed: HTTP {}", resp.status()),
+            });
+        }
+
+        #[derive(Deserialize)]
+        struct TokenResponse {
+            access_token: String,
+        }
+        let token: TokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| parse_err("Spotify token", e))?;
+        Ok(token.access_token)
+    }
+
+    /// Parse a Spotify track search response into `ProviderResult`s.
+    fn parse_tracks(provider_name: &str, body: &str) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        struct SpotifySearchResponse {
+            tracks: Option<SpotifyTrackPage>,
+        }
+        #[derive(Deserialize)]
+        struct SpotifyTrackPage {
+            items: Vec<SpotifyTrack>,
+        }
+        #[derive(Deserialize)]
+        struct SpotifyTrack {
+            id: Option<String>,
+            name: Option<String>,
+            artists: Option<Vec<SpotifyArtist>>,
+            album: Option<SpotifyAlbum>,
+            duration_ms: Option<u64>,
+            explicit: Option<bool>,
+            external_ids: Option<SpotifyExternalIds>,
+            popularity: Option<u32>,
+        }
+        #[derive(Deserialize)]
+        struct SpotifyArtist {
+            name: Option<String>,
+        }
+        #[derive(Deserialize)]
+        struct SpotifyAlbum {
+            name: Option<String>,
+            release_date: Option<String>,
+            images: Option<Vec<SpotifyImage>>,
+        }
+        #[derive(Deserialize)]
+        struct SpotifyImage {
+            url: String,
+            width: Option<u32>,
+            height: Option<u32>,
+        }
+        #[derive(Deserialize)]
+        struct SpotifyExternalIds {
+            isrc: Option<String>,
+        }
+
+        let resp: SpotifySearchResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("Spotify search", e))?;
+
+        let tracks = resp.tracks.map(|p| p.items).unwrap_or_default();
+
+        let results = tracks
+            .into_iter()
+            .map(|track| {
+                let artist = track.artists.as_deref().map(|artists| {
+                    artists
+                        .iter()
+                        .filter_map(|a| a.name.as_deref())
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                });
+                let album_name = track.album.as_ref().and_then(|a| a.name.clone());
+                let year = track
+                    .album
+                    .as_ref()
+                    .and_then(|a| a.release_date.as_deref())
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+                let cover_art = track
+                    .album
+                    .as_ref()
+                    .and_then(|a| a.images.as_deref())
+                    .map(|imgs| {
+                        imgs.iter()
+                            .map(|img| CoverArtInfo {
+                                url: img.url.clone(),
+                                width: img.width,
+                                height: img.height,
+                                mime_type: Some("image/jpeg".into()),
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                let isrc = track.external_ids.and_then(|ids| ids.isrc);
+                // Normalise Spotify popularity 0–100 to [0.0, 1.0]
+                let score = f64::from(track.popularity.unwrap_or(0)) / 100.0;
+                let content_advisory = if track.explicit.unwrap_or(false) {
+                    "explicit"
+                } else {
+                    "clean"
+                };
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = track.name;
+                result.artist = artist;
+                result.album = album_name;
+                result.year = year;
+                result.isrc = isrc;
+                result.score = score;
+                result.cover_art = cover_art;
+                result.metadata.insert(
+                    CONTENT_ADVISORY.into(),
+                    Value::String(content_advisory.into()),
+                );
+                if let Some(id) = track.id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id));
+                }
+                if let Some(ms) = track.duration_ms {
+                    insert_duration(&mut result, ms as f64 / 1000.0);
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for SpotifyProvider {
+    fn id(&self) -> &str {
+        "spotify"
+    }
+
+    fn display_name(&self) -> &str {
+        "Spotify"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: true,
+            video_search: false,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("spotify".into()));
+        }
+
+        let token = self.get_access_token().await?;
+
+        // Build Spotify search query
+        let sp_query = if let Some(isrc) = &query.isrc {
+            format!("isrc:{isrc}")
+        } else {
+            let mut parts = Vec::new();
+            if let Some(title) = &query.title {
+                parts.push(format!("track:{title}"));
+            }
+            if let Some(artist) = &query.artist {
+                parts.push(format!("artist:{artist}"));
+            }
+            if parts.is_empty() {
+                search_term(query)
+            } else {
+                parts.join(" ")
+            }
+        };
+
+        let url = format!("{}/v1/search", self.base_url);
+        debug!(
+            provider = "spotify",
+            query = &sp_query,
+            "Sending search request"
+        );
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&token)
+            .query(&[
+                ("q", &sp_query),
+                ("type", &"track".to_owned()),
+                ("limit", &limit),
+            ])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            if status.as_u16() == 429 {
+                return Err(ProviderError::RateLimited("spotify".into()));
+            }
+            return Err(ProviderError::NetworkError(format!("HTTP {status}")));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_tracks("spotify", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spotify_name() {
+        let p = SpotifyProvider::new(Some("id".into()), Some("secret".into()));
+        assert_eq!(p.id(), "spotify");
+    }
+
+    #[test]
+    fn spotify_capabilities_provides_cover_art() {
+        let p = SpotifyProvider::new(None, None);
+        assert!(p.capabilities().cover_art);
+    }
+
+    #[test]
+    fn spotify_capabilities_music_search() {
+        let p = SpotifyProvider::new(None, None);
+        assert!(p.capabilities().music_search);
+    }
+
+    #[test]
+    fn spotify_parse_tracks_valid_json() {
+        let json = r#"{
+            "tracks": {
+                "items": [{
+                    "id": "sp123",
+                    "name": "Bohemian Rhapsody",
+                    "artists": [{"name": "Queen"}],
+                    "album": {
+                        "name": "A Night at the Opera",
+                        "release_date": "1975-11-21",
+                        "images": [{"url": "https://img.spotify.com/big.jpg", "width": 640, "height": 640}]
+                    },
+                    "duration_ms": 354000,
+                    "explicit": false,
+                    "external_ids": {"isrc": "GBUM71505078"},
+                    "popularity": 90
+                }]
+            }
+        }"#;
+        let results = SpotifyProvider::parse_tracks("spotify", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Bohemian Rhapsody"));
+        assert_eq!(results[0].artist.as_deref(), Some("Queen"));
+        assert_eq!(results[0].album.as_deref(), Some("A Night at the Opera"));
+        assert_eq!(results[0].year, Some(1975));
+        assert_eq!(results[0].isrc.as_deref(), Some("GBUM71505078"));
+        assert!((results[0].score - 0.9).abs() < 1e-9);
+        assert!(!results[0].cover_art.is_empty());
+    }
+
+    #[test]
+    fn spotify_parse_tracks_empty() {
+        let json = r#"{"tracks": {"items": []}}"#;
+        let results = SpotifyProvider::parse_tracks("spotify", json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn spotify_parse_tracks_invalid_json() {
+        let result = SpotifyProvider::parse_tracks("spotify", "bad json");
+        assert!(matches!(result, Err(ProviderError::Other(_))));
+    }
+
+    #[test]
+    fn spotify_parse_explicit_track_flagged() {
+        let json =
+            r#"{"tracks": {"items": [{"id": "x","name": "T","explicit": true,"popularity": 0}]}}"#;
+        let results = SpotifyProvider::parse_tracks("spotify", json).unwrap();
+        assert_eq!(
+            results[0]
+                .metadata
+                .get(CONTENT_ADVISORY)
+                .and_then(serde_json::Value::as_str),
+            Some("explicit")
+        );
+    }
+}

--- a/crates/meedya-providers/src/providers/thetvdb.rs
+++ b/crates/meedya-providers/src/providers/thetvdb.rs
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// TheTVDB provider.
+// Ported from MeedyaManager crates/mm-providers/src/video/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::PROVIDER_ID;
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+/// Searches TheTVDB for TV shows and episodes.
+///
+/// Endpoint: `https://api4.thetvdb.com/v4/search`
+/// Auth:     API key (Bearer token obtained via `/login`)
+/// Limits:   30 RPM
+pub struct TheTvdbProvider {
+    client: Client,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl TheTvdbProvider {
+    pub fn new(api_key: Option<String>) -> Self {
+        Self::with_base_url(api_key, "https://api4.thetvdb.com")
+    }
+
+    pub fn with_base_url(api_key: Option<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            api_key,
+        }
+    }
+
+    fn configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    fn parse_search(provider_name: &str, body: &str) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        struct TvdbResponse {
+            data: Option<Vec<TvdbResult>>,
+        }
+        #[derive(Deserialize)]
+        struct TvdbResult {
+            id: Option<String>,
+            name: Option<String>,
+            first_air_time: Option<String>,
+            image_url: Option<String>,
+            overview: Option<String>,
+            #[serde(rename = "type")]
+            media_type: Option<String>,
+        }
+
+        let resp: TvdbResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("TheTVDB response", e))?;
+
+        let data = resp.data.unwrap_or_default();
+        let results = data
+            .into_iter()
+            .map(|r| {
+                let year = r
+                    .first_air_time
+                    .as_deref()
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+                let cover_art = r
+                    .image_url
+                    .as_deref()
+                    .filter(|u| !u.is_empty())
+                    .map(|u| {
+                        vec![CoverArtInfo {
+                            url: u.to_owned(),
+                            width: None,
+                            height: None,
+                            mime_type: Some("image/jpeg".into()),
+                        }]
+                    })
+                    .unwrap_or_default();
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = r.name;
+                result.year = year;
+                result.cover_art = cover_art;
+
+                if let Some(id) = r.id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id));
+                }
+                if let Some(o) = r.overview {
+                    result.metadata.insert("overview".into(), Value::String(o));
+                }
+                if let Some(t) = r.media_type {
+                    result
+                        .metadata
+                        .insert("media_type".into(), Value::String(t));
+                }
+
+                result
+            })
+            .collect();
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for TheTvdbProvider {
+    fn id(&self) -> &str {
+        "thetvdb"
+    }
+
+    fn display_name(&self) -> &str {
+        "TheTVDB"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: false,
+            video_search: true,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("thetvdb".into()));
+        }
+        let key = self.api_key.as_deref().unwrap();
+        let fallback = format!(
+            "{} {}",
+            query.title.as_deref().unwrap_or(""),
+            query.artist.as_deref().unwrap_or("")
+        );
+        let q: &str = query.title.as_deref().unwrap_or(fallback.trim());
+
+        debug!(provider = "thetvdb", query = q, "Sending search request");
+
+        let limit = query.max_results.unwrap_or(10).to_string();
+        let url = format!("{}/v4/search", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(key)
+            .query(&[("query", q), ("limit", &limit)])
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            return Err(ProviderError::NetworkError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        Self::parse_search("thetvdb", &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tvdb_name() {
+        let p = TheTvdbProvider::new(Some("key".into()));
+        assert_eq!(p.id(), "thetvdb");
+    }
+
+    #[test]
+    fn tvdb_capabilities_video_type() {
+        let caps = TheTvdbProvider::new(None).capabilities();
+        assert!(caps.video_search);
+    }
+
+    #[test]
+    fn tvdb_parse_search_valid_json() {
+        let json = r#"{
+            "data": [{
+                "id": "series-1396",
+                "name": "Breaking Bad",
+                "first_air_time": "2008-01-20",
+                "image_url": "https://artworks.thetvdb.com/banners/bb.jpg",
+                "overview": "A high school chemistry teacher...",
+                "type": "series"
+            }]
+        }"#;
+        let results = TheTvdbProvider::parse_search("thetvdb", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Breaking Bad"));
+        assert_eq!(results[0].year, Some(2008));
+        assert!(!results[0].cover_art.is_empty());
+        assert_eq!(
+            results[0]
+                .metadata
+                .get("media_type")
+                .and_then(serde_json::Value::as_str),
+            Some("series")
+        );
+    }
+
+    #[test]
+    fn tvdb_parse_null_data_returns_empty() {
+        let json = r#"{"data": null}"#;
+        let results = TheTvdbProvider::parse_search("thetvdb", json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn tvdb_parse_invalid_json_returns_err() {
+        assert!(matches!(
+            TheTvdbProvider::parse_search("thetvdb", "garbage"),
+            Err(ProviderError::Other(_))
+        ));
+    }
+}

--- a/crates/meedya-providers/src/providers/tmdb.rs
+++ b/crates/meedya-providers/src/providers/tmdb.rs
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License.
+//
+// TMDb (The Movie Database) provider.
+// Ported from MeedyaManager crates/mm-providers/src/video/mod.rs
+// under MeedyaSuite-core#12 / MeedyaManager#136.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::extra_keys::PROVIDER_ID;
+use crate::traits::{MetadataProvider, ProviderCapabilities, ProviderError};
+use crate::types::{CoverArtInfo, ProviderResult, SearchQuery};
+
+fn net_err(e: reqwest::Error) -> ProviderError {
+    ProviderError::NetworkError(e.to_string())
+}
+
+fn parse_err(context: &str, e: impl std::fmt::Display) -> ProviderError {
+    ProviderError::Other(format!("parse error: {context}: {e}"))
+}
+
+/// Searches The Movie Database (TMDb) for films and TV shows.
+///
+/// Endpoint: `https://api.themoviedb.org/3/search/multi`
+/// Auth:     API key (`api_key` query param or Bearer token)
+/// Limits:   40 RPM
+pub struct TmdbProvider {
+    client: Client,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl TmdbProvider {
+    pub fn new(api_key: Option<String>) -> Self {
+        Self::with_base_url(api_key, "https://api.themoviedb.org")
+    }
+
+    pub fn with_base_url(api_key: Option<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            api_key,
+        }
+    }
+
+    fn configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    fn parse_multi_search(
+        provider_name: &str,
+        body: &str,
+    ) -> Result<Vec<ProviderResult>, ProviderError> {
+        #[derive(Deserialize)]
+        struct TmdbResponse {
+            results: Vec<TmdbResult>,
+        }
+
+        #[derive(Deserialize)]
+        struct TmdbResult {
+            id: Option<u64>,
+            media_type: Option<String>,
+            title: Option<String>, // movies
+            name: Option<String>,  // TV shows
+            overview: Option<String>,
+            release_date: Option<String>,   // movies
+            first_air_date: Option<String>, // TV shows
+            poster_path: Option<String>,
+            vote_average: Option<f64>,
+            #[allow(dead_code)]
+            genre_ids: Option<Vec<u32>>,
+        }
+
+        let resp: TmdbResponse =
+            serde_json::from_str(body).map_err(|e| parse_err("TMDb response", e))?;
+
+        const IMAGE_BASE: &str = "https://image.tmdb.org/t/p";
+
+        let results = resp
+            .results
+            .into_iter()
+            .map(|r| {
+                let title = r.title.or(r.name);
+                let year = r
+                    .release_date
+                    .as_deref()
+                    .or(r.first_air_date.as_deref())
+                    .and_then(|d| d[..4.min(d.len())].parse::<u32>().ok());
+                let cover_art = r
+                    .poster_path
+                    .as_deref()
+                    .map(|p| {
+                        vec![
+                            CoverArtInfo {
+                                url: format!("{IMAGE_BASE}/original{p}"),
+                                width: None,
+                                height: None,
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                            CoverArtInfo {
+                                url: format!("{IMAGE_BASE}/w500{p}"),
+                                width: Some(500),
+                                height: Some(750),
+                                mime_type: Some("image/jpeg".into()),
+                            },
+                        ]
+                    })
+                    .unwrap_or_default();
+                let score = r.vote_average.map_or(0.5, |v| (v / 10.0).clamp(0.0, 1.0));
+
+                let mut result = ProviderResult::new(provider_name);
+                result.title = title;
+                result.year = year;
+                result.cover_art = cover_art;
+                result.score = score;
+
+                if let Some(id) = r.id {
+                    result
+                        .metadata
+                        .insert(PROVIDER_ID.into(), Value::String(id.to_string()));
+                }
+                if let Some(overview) = r.overview {
+                    if !overview.is_empty() {
+                        result
+                            .metadata
+                            .insert("overview".into(), Value::String(overview));
+                    }
+                }
+                if let Some(mt) = &r.media_type {
+                    result
+                        .metadata
+                        .insert("media_type".into(), Value::String(mt.clone()));
+                }
+
+                result
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for TmdbProvider {
+    fn id(&self) -> &str {
+        "tmdb"
+    }
+
+    fn display_name(&self) -> &str {
+        "The Movie Database (TMDb)"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            music_search: false,
+            video_search: true,
+            podcast_search: false,
+            cover_art: true,
+            lyrics: false,
+            fingerprint_lookup: false,
+            identifier_lookup: false,
+        }
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, ProviderError> {
+        if !self.configured() {
+            return Err(ProviderError::NotConfigured("tmdb".into()));
+        }
+        let key = self.api_key.as_deref().unwrap();
+        let title_fallback = format!(
+            "{} {}",
+            query.title.as_deref().unwrap_or(""),
+            query.artist.as_deref().unwrap_or("")
+        );
+        let search_query: String = query
+            .title
+            .clone()
+            .unwrap_or_else(|| title_fallback.trim().to_owned());
+
+        debug!(
+            provider = "tmdb",
+            query = %search_query,
+            "Sending search request"
+        );
+
+        let mut params = vec![
+            ("api_key", key.to_owned()),
+            ("query", search_query),
+            ("page", "1".to_owned()),
+        ];
+        if let Some(year) = query.year {
+            params.push(("year", year.to_string()));
+        }
+
+        let url = format!("{}/3/search/multi", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&params)
+            .send()
+            .await
+            .map_err(net_err)?;
+
+        if !response.status().is_success() {
+            let s = response.status();
+            if s.as_u16() == 429 {
+                return Err(ProviderError::RateLimited("tmdb".into()));
+            }
+            return Err(ProviderError::NetworkError(format!("HTTP {s}")));
+        }
+
+        let body = response.text().await.map_err(net_err)?;
+        let mut results = Self::parse_multi_search("tmdb", &body)?;
+        results.truncate(query.max_results.unwrap_or(10));
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmdb_name() {
+        let p = TmdbProvider::new(Some("key".into()));
+        assert_eq!(p.id(), "tmdb");
+    }
+
+    #[test]
+    fn tmdb_capabilities_video_type() {
+        let caps = TmdbProvider::new(None).capabilities();
+        assert!(caps.video_search);
+        assert!(!caps.music_search);
+        assert!(caps.cover_art);
+    }
+
+    #[test]
+    fn tmdb_parse_multi_search_valid_json() {
+        let json = r#"{
+            "results": [{
+                "id": 27205,
+                "media_type": "movie",
+                "title": "Inception",
+                "overview": "A thief who steals corporate secrets...",
+                "release_date": "2010-07-16",
+                "poster_path": "/9gk7adHYeDvHkCSEqAvQNLV5Uge.jpg",
+                "vote_average": 8.4
+            }]
+        }"#;
+        let results = TmdbProvider::parse_multi_search("tmdb", json).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.as_deref(), Some("Inception"));
+        assert_eq!(results[0].year, Some(2010));
+        assert!((results[0].score - 0.84).abs() < 1e-9);
+        assert!(!results[0].cover_art.is_empty());
+        // Original image URL should be in cover art
+        assert!(results[0]
+            .cover_art
+            .iter()
+            .any(|a| a.url.contains("original")));
+    }
+
+    #[test]
+    fn tmdb_parse_tv_show_uses_name_field() {
+        let json = r#"{
+            "results": [{
+                "id": 1396,
+                "media_type": "tv",
+                "name": "Breaking Bad",
+                "first_air_date": "2008-01-20",
+                "vote_average": 9.5
+            }]
+        }"#;
+        let results = TmdbProvider::parse_multi_search("tmdb", json).unwrap();
+        assert_eq!(results[0].title.as_deref(), Some("Breaking Bad"));
+        assert_eq!(results[0].year, Some(2008));
+    }
+
+    #[test]
+    fn tmdb_parse_empty_results() {
+        let json = r#"{"results": []}"#;
+        let results = TmdbProvider::parse_multi_search("tmdb", json).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn tmdb_parse_invalid_json_returns_err() {
+        let result = TmdbProvider::parse_multi_search("tmdb", "bad json");
+        assert!(matches!(result, Err(ProviderError::Other(_))));
+    }
+
+    #[test]
+    fn tmdb_parse_overview_stored_in_metadata() {
+        let json =
+            r#"{"results": [{"id": 1, "media_type": "movie", "overview": "Description here"}]}"#;
+        let results = TmdbProvider::parse_multi_search("tmdb", json).unwrap();
+        assert_eq!(
+            results[0]
+                .metadata
+                .get("overview")
+                .and_then(serde_json::Value::as_str),
+            Some("Description here")
+        );
+    }
+
+    #[test]
+    fn tmdb_parse_score_normalised_from_vote_average() {
+        // vote_average = 7.5 → score = 0.75
+        let json = r#"{"results": [{"id": 1, "media_type": "movie", "vote_average": 7.5}]}"#;
+        let results = TmdbProvider::parse_multi_search("tmdb", json).unwrap();
+        assert!((results[0].score - 0.75).abs() < 1e-9);
+    }
+}

--- a/crates/meedya-providers/src/traits.rs
+++ b/crates/meedya-providers/src/traits.rs
@@ -33,6 +33,18 @@ pub enum ProviderError {
     Other(String),
 }
 
+/// Returns `true` for transient errors that may succeed on retry.
+///
+/// Useful for orchestrators (retry loops, circuit breakers) deciding whether
+/// to back off and try again or fail fast. Network errors and explicit
+/// rate-limit responses are retryable; auth failures and parse errors are not.
+pub fn is_retryable(err: &ProviderError) -> bool {
+    matches!(
+        err,
+        ProviderError::NetworkError(_) | ProviderError::RateLimited(_)
+    )
+}
+
 /// Capabilities that a metadata provider supports.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderCapabilities {

--- a/crates/meedya-providers/src/types.rs
+++ b/crates/meedya-providers/src/types.rs
@@ -50,6 +50,60 @@ pub struct SearchQuery {
     pub musicbrainz_id: Option<String>,
 }
 
+impl SearchQuery {
+    /// Create a simple title + artist music query (max 10 results).
+    pub fn music(title: impl Into<String>, artist: impl Into<String>) -> Self {
+        Self {
+            title: Some(title.into()),
+            artist: Some(artist.into()),
+            media_type: Some(MediaType::Music),
+            max_results: Some(10),
+            ..Default::default()
+        }
+    }
+
+    /// Create a video / film lookup query (max 10 results).
+    pub fn video(title: impl Into<String>, year: Option<u32>) -> Self {
+        Self {
+            title: Some(title.into()),
+            year,
+            media_type: Some(MediaType::Video),
+            max_results: Some(10),
+            ..Default::default()
+        }
+    }
+
+    /// Create a query by ISRC identifier (max 5 results).
+    pub fn by_isrc(isrc: impl Into<String>) -> Self {
+        Self {
+            isrc: Some(isrc.into()),
+            media_type: Some(MediaType::Identifier),
+            max_results: Some(5),
+            ..Default::default()
+        }
+    }
+
+    /// Create a query by ISWC identifier (max 5 results).
+    pub fn by_iswc(iswc: impl Into<String>) -> Self {
+        Self {
+            iswc: Some(iswc.into()),
+            media_type: Some(MediaType::Identifier),
+            max_results: Some(5),
+            ..Default::default()
+        }
+    }
+
+    /// Create a query by EIDR identifier (max 5 results).
+    pub fn by_eidr(eidr: impl Into<String>) -> Self {
+        Self {
+            eidr: Some(eidr.into()),
+            media_type: Some(MediaType::Identifier),
+            max_results: Some(5),
+            ..Default::default()
+        }
+    }
+}
+
 /// A standardized result returned by any provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderResult {


### PR DESCRIPTION
## Summary

Phase 5 of the MeedyaSuite-core integration epic (MeedyaManager#136). Ports 13 concrete metadata provider implementations from MeedyaManager's \`mm-providers\` into the upstream \`meedya-providers\` crate, gated behind per-provider Cargo feature flags so downstream apps opt into only what they need.

Closes #12 (parent epic).

## Per-provider port status — all 13 in scope landed

| Category | Provider | Auth | Tests |
|---|---|---|---|
| music | MusicBrainz | none (rate-limited) | 5 |
| music | Deezer | none (public) | 4 |
| music | Apple Music | none (iTunes Search) | 4 |
| video | Apple TV | none (iTunes Search) | 3 |
| video | iTunes Store | none (iTunes Search) | 3 |
| podcasts | Apple Podcasts | none (iTunes Search) | 9 |
| identifiers | ISRC | none (MusicBrainz-backed) | 11 |
| identifiers | ISWC | none (MusicBrainz-backed) | 10 |
| identifiers | EIDR | optional basic-auth | 6 |
| video | OMDb | API key | 4 |
| video | TMDb | API key | 7 |
| video | TheTVDB | bearer token | 4 |
| music | Spotify | OAuth2 client-credentials | 5 |
| **Total** | **13** | | **75 unit tests** |

The 6 stub providers in MM (YouTube Music, Amazon Music, Pandora, Tidal, Shazam, iHeart) were intentionally skipped — they're MM-specific placeholders that return \`NotSupported\`.

## What this PR adds

**Foundation (commit \`880ab88\`):**
- \`src/extra_keys.rs\` — 8 standard metadata-key constants (\`ALBUM_ARTIST\`, \`TRACK_TOTAL\`, \`ISWC\`, \`EIDR\`, \`CONTENT_ADVISORY\`, \`DURATION_SECS\`, \`BPM\`, \`PROVIDER_ID\`) for the \`ProviderResult::metadata\` blob
- \`src/traits.rs\` — \`pub fn is_retryable(err)\` free fn
- \`src/types.rs\` — \`SearchQuery::{music, video, by_isrc, by_iswc, by_eidr}\` constructors
- \`src/cover_art.rs\` — \`best_cover_art(r)\` / \`has_cover_art(r)\` free fns
- \`Cargo.toml\` — 13 \`provider-<name>\` features + \`provider-all\` umbrella + optional \`oauth2\` (Spotify) / \`jsonwebtoken\` (Apple Music)

**13 provider modules** under \`src/providers/\`, each behind its own feature flag.

**Trivial drive-by fix (commit \`e08cd68\`):** \`clippy::manual_find\` lint in \`meedya-codecs/src/container.rs::from_extension\` — was the only blocker on the provider-port PR's exit conditions.

## Decisions worth a sanity check

1. **HTTP client construction**: each provider builds its own \`reqwest::Client\` inline. MusicBrainz / ISRC / ISWC pass their User-Agent string to \`Client::builder().user_agent(...)\` (MB API requires it); others use plain \`Client::new()\`. No shared \`http.rs\` module — kept module surface minimal.

2. **iTunes Store inlines its parser** (rather than depending on \`AppleTvProvider::parse_itunes_video()\` as MM does). The two providers can be feature-gated independently; cross-feature dependencies would be fragile.

3. **Env-var prefix**: \`MEEDYA_<PROVIDER>_<KEY>\` upstream (MM was \`MM_<PROVIDER>_<KEY>\`). The existing \`CredentialStore\` already uses \`MEEDYA_\`; the 13 ports flow through it, no env-var string-literal changes needed in provider code itself.

4. **Apple Music JWT is wired but unused**. \`provider-apple-music = [\"dep:jsonwebtoken\"]\` pulls in jsonwebtoken; the port uses only the iTunes Search path (no auth). The dep is in place for future MusicKit support.

5. **License headers**: all 14 new files start with \`// Copyright (c) 2026 MeedyaSuite\` / MIT (NOT MWBM).

6. **No live-HTTP tests added.** MM's tests are all constructor / parse / capability tests; same set carried over verbatim.

## Local verification

```
$ cargo fmt --check                                                            → clean
$ cargo check -p meedya-providers                                              → clean (default = no providers)
$ cargo check -p meedya-providers --features provider-all                      → clean
$ cargo check --workspace                                                      → clean
$ cargo clippy -p meedya-providers --features provider-all --tests -- -D warnings  → clean
$ cargo test -p meedya-providers --features provider-all                       → 112 passed, 0 failed
```

## Commits

```
e08cd68 style(codecs): clippy::manual_find on ContainerFormat::from_extension
1977286 feat(providers): port OMDb, TMDb, TheTVDB, Spotify (auth-required) from MeedyaManager
cc6ed94 feat(providers): port ISRC, ISWC, EIDR identifier providers from MeedyaManager
09a1736 feat(providers): port Deezer, Apple Music, Apple TV, iTunes Store, Apple Podcasts from MeedyaManager
9adba65 feat(providers): port MusicBrainzProvider from MeedyaManager
880ab88 feat(providers): scaffold provider feature flags + helpers ported from MeedyaManager
```

## Net line count

\`+4348 / -13\`. The 13 line removals come from foundation refactoring. The 13 provider modules + \`providers/mod.rs\` are ~3953 net additions.

## Test plan

- [ ] CI passes
- [ ] Merge
- [ ] Downstream follow-up PR against MeedyaManager replaces its local \`crates/mm-providers/src/{music,video,identifiers,podcasts}/mod.rs\` with consumption of \`meedya_providers::providers::*\` (tracked under MM #136 final step; ~3953-line deletion in MM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)