### PR TITLE
chore(claude): recover deep-architect + quick-edits subagent configs

### DIFF
--- a/.claude/agents/deep-architect.md
+++ b/.claude/agents/deep-architect.md
@@ -1,0 +1,8 @@
+---
+name: deep-architect
+description: Use ONLY for genuinely hard reasoning — architecture decisions, subtle multi-file bugs, algorithm design, concurrency or data-model trade-offs, large cross-cutting refactors.
+model: claude-fable-5
+tools: Read, Edit, Bash, Grep, Glob
+---
+You handle complex reasoning. Weigh trade-offs explicitly and explain the
+decision before implementing. Prefer correctness over speed.

--- a/.claude/agents/quick-edits.md
+++ b/.claude/agents/quick-edits.md
@@ -1,0 +1,8 @@
+---
+name: quick-edits
+description: Use PROACTIVELY for mechanical, low-reasoning work — renames, formatting, import sorting, docstrings, boilerplate, simple find-and-replace across files, trivial config edits.
+model: claude-haiku-4-5
+tools: Read, Edit, Bash
+---
+You handle fast, mechanical changes. Make the edit, verify it builds or compiles
+if relevant, then stop. Do not redesign or refactor beyond what was asked.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,5 +7,8 @@
       "Bash(cargo fmt:*)",
       "Bash(git:*)"
     ]
+  },
+  "enabledPlugins": {
+    "dev-team@dev-team": true
   }
 }


### PR DESCRIPTION
## Summary
Recovers the two project **subagent definitions** and the `dev-team` plugin enablement that were only ever committed to the now-superseded `feat/60-syllable-schema-and-classifier` branch (commit `21a20b3`, "recover project agent configuration"). The #60 feature itself (syllable schema + `TtmlGranularity` classifier) is already in `main` via #62 — only this incidental Claude Code tooling config was unique to that branch tip.

## Included
- `.claude/agents/deep-architect.md` — subagent definition for hard reasoning tasks
- `.claude/agents/quick-edits.md` — subagent definition for mechanical edits
- `.claude/settings.json` — enables the `dev-team@dev-team` plugin

## Intentionally excluded
- `.claude/settings.local.json` — the per-user *local* settings layer. It hardcodes a machine-specific absolute path, so it does not belong in shared version control.

## Why
Part of a branch-cleanup audit. This recovers the only content unique to `feat/60` before that branch — and three other fully-superseded branches (`feat/596-lyricsfile-yaml-format`, `feat/353-chromaprint-feature-flag`, `feature/provider-implementations`) — are deleted. No library/source changes; `.claude/` tooling only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMgUG5ZxiuQPHG2NRVjpPY)_